### PR TITLE
Fix gcs tests

### DIFF
--- a/mlrun/datastore/azure_blob.py
+++ b/mlrun/datastore/azure_blob.py
@@ -229,11 +229,18 @@ class AzureBlobStore(DataStore):
         st = self.storage_options
         service = "blob"
         primary_url = None
-        if st.get("connection_string"):
+        connection_string = st.get("connection_string")
+        if connection_string:
             primary_url, _, parsed_credential = parse_connection_str(
-                st.get("connection_string"), credential=None, service=service
+                connection_string, credential=None, service=service
             )
-            for key in ["account_name", "account_key"]:
+
+            if isinstance(parsed_credential, str):
+                sas_str = parsed_credential
+                parsed_credential = {}
+                parsed_credential["sas_token"] = sas_str
+
+            for key in ["account_name", "account_key", "sas_token"]:
                 parsed_value = parsed_credential.get(key)
                 if parsed_value:
                     if key in st and st[key] != parsed_value:
@@ -259,6 +266,8 @@ class AzureBlobStore(DataStore):
             host = f"{account_name}.{service}.core.windows.net"
         else:
             return res
+
+        host = host.rstrip("/")
 
         if "account_key" in st:
             res[f"spark.hadoop.fs.azure.account.key.{host}"] = st["account_key"]

--- a/mlrun/datastore/datastore_profile.py
+++ b/mlrun/datastore/datastore_profile.py
@@ -333,7 +333,9 @@ class DatastoreProfileGCS(DatastoreProfile):
             #  in gcs the path after schema is starts with bucket, wherefore it should not start with "/".
             subpath = subpath[1:]
         if self.bucket:
-            return f"gcs://{self.bucket}/{subpath}"
+            return (
+                f"gcs://{self.bucket}/{subpath}" if subpath else f"gcs://{self.bucket}"
+            )
         else:
             return f"gcs://{subpath}"
 
@@ -370,7 +372,11 @@ class DatastoreProfileAzureBlob(DatastoreProfile):
             #  in azure the path after schema is starts with container, wherefore it should not start with "/".
             subpath = subpath[1:]
         if self.container:
-            return f"az://{self.container}/{subpath}"
+            return (
+                f"az://{self.container}/{subpath}"
+                if subpath
+                else f"az://{self.container}"
+            )
         else:
             return f"az://{subpath}"
 

--- a/tests/integration/aws_s3/test_aws_s3.py
+++ b/tests/integration/aws_s3/test_aws_s3.py
@@ -84,7 +84,7 @@ class TestAwsS3:
 
     @classmethod
     def teardown_class(cls):
-        test_dir = f"{cls.bucket_name}{cls.test_dir}"
+        test_dir = f"{cls.test_dir}"
         if not cls._fs:
             return
         if cls._fs.exists(test_dir):
@@ -97,6 +97,7 @@ class TestAwsS3:
             name=self.profile_name,
             access_key_id=self.access_key_id,
             secret_key=self._secret_access_key,
+            bucket=self.bucket_name,
         )
         register_temporary_client_datastore_profile(self.profile)
 
@@ -113,12 +114,12 @@ class TestAwsS3:
         if use_datastore_profile:
             os.environ["AWS_ACCESS_KEY_ID"] = "wrong_access_key"
             os.environ["AWS_SECRET_ACCESS_KEY"] = "wrong_token"
-            self.prefix_path = f"ds://{self.profile_name}/"
+            self.prefix_path = f"ds://{self.profile_name}"
         else:
             os.environ["AWS_ACCESS_KEY_ID"] = self.access_key_id
             os.environ["AWS_SECRET_ACCESS_KEY"] = self._secret_access_key
-            self.prefix_path = "s3://"
-        self._bucket_path = f"{self.prefix_path}{self.bucket_name}"
+            self.prefix_path = f"s3://{self.bucket_name}"
+        self._bucket_path = self.prefix_path
         self.run_dir_url = f"{self._bucket_path}{self.run_dir}"
         object_file = f"/file_{uuid.uuid4()}.txt"
         self.object_url = f"{self.run_dir_url}{object_file}"
@@ -374,7 +375,7 @@ class TestAwsS3:
         )
         if use_datastore_profile:
             self.profile = DatastoreProfileS3(
-                name=self.profile_name, **credentials_dict
+                name=self.profile_name, bucket=self.bucket_name, **credentials_dict
             )
             register_temporary_client_datastore_profile(self.profile)
         else:

--- a/tests/integration/azure_blob/test_azure_blob.py
+++ b/tests/integration/azure_blob/test_azure_blob.py
@@ -139,7 +139,7 @@ class TestAzureBlob:
     def build_object_url(self, use_datastore_profile):
         self.object_file = f"/file_{uuid.uuid4()}.txt"
         if use_datastore_profile:
-            self._bucket_url = f"ds://{self.profile_name}/{self.bucket_name}"
+            self._bucket_url = f"ds://{self.profile_name}"
         else:
             self._bucket_url = f"az://{self.bucket_name}"
         self.run_dir_url = f"{self._bucket_url}/{self.run_dir}"
@@ -184,7 +184,9 @@ class TestAzureBlob:
             logger.info(f"Testing auth method {auth_method}")
             if use_datastore_profile:
                 self.profile = DatastoreProfileAzureBlob(
-                    name=self.profile_name, **self.storage_options
+                    name=self.profile_name,
+                    container=self.bucket_name,
+                    **self.storage_options,
                 )
                 register_temporary_client_datastore_profile(self.profile)
         else:
@@ -442,7 +444,9 @@ class TestAzureBlob:
         pop_env()
         self.build_object_url(use_datastore_profile)
         if use_datastore_profile:
-            profile = DatastoreProfileAzureBlob(name=self.profile_name)
+            profile = DatastoreProfileAzureBlob(
+                name=self.profile_name, container=self.bucket_name
+            )
             register_temporary_client_datastore_profile(profile)
         data_item = mlrun.run.get_dataitem(self.object_url)
         with pytest.raises(ValueError):

--- a/tests/integration/google_cloud_storage/test_google_cloud_storage.py
+++ b/tests/integration/google_cloud_storage/test_google_cloud_storage.py
@@ -109,7 +109,9 @@ class TestGoogleCloudStorage:
                 kwargs = {"credentials_path": self.credentials_path}
             else:
                 kwargs = {"gcp_credentials": self.credentials}
-            profile = DatastoreProfileGCS(name=self.profile_name, **kwargs)
+            profile = DatastoreProfileGCS(
+                name=self.profile_name, bucket=self.bucket_name, **kwargs
+            )
             register_temporary_client_datastore_profile(profile)
 
     @pytest.fixture(autouse=True)
@@ -121,7 +123,7 @@ class TestGoogleCloudStorage:
         os.environ.pop("GCP_CREDENTIALS", None)
         remove_temporary_client_datastore_profile(self.profile_name)
         self._bucket_path = (
-            f"ds://{self.profile_name}/{self.bucket_name}"
+            f"ds://{self.profile_name}"
             if use_datastore_profile
             else f"gcs://{self.bucket_name}"
         )
@@ -440,7 +442,7 @@ class TestGoogleCloudStorage:
                 {"gcp_credentials": fake_credentials} if credentials_value else {}
             )
             self.profile = DatastoreProfileGCS(
-                name=self.profile_name, **gcp_credentials_dict
+                name=self.profile_name, bucket=self.bucket_name, **gcp_credentials_dict
             )
             register_temporary_client_datastore_profile(self.profile)
         elif fake_credentials:

--- a/tests/integration/google_cloud_storage/test_google_cloud_storage.py
+++ b/tests/integration/google_cloud_storage/test_google_cloud_storage.py
@@ -91,16 +91,11 @@ class TestGoogleCloudStorage:
     def setup_class(cls):
         with open(cls.test_file) as f:
             cls.test_string = f.read()
-        try:
-            credentials = json.loads(cls.credentials_path)
-            token = credentials
-            cls.credentials = cls.credentials_path
-        except json.JSONDecodeError:
-            token = cls.credentials_path
-            with open(cls.credentials_path) as gcs_credentials_path:
-                cls.credentials = gcs_credentials_path.read()
+        with open(cls.credentials_path) as gcs_credentials_path:
+            #  environ expect credentials as string
+            cls.credentials = gcs_credentials_path.read()
 
-        cls._gcs_fs = fsspec.filesystem("gcs", token=token)
+        cls._gcs_fs = fsspec.filesystem("gcs", token=json.loads(cls.credentials))
         cls.clean_test_directory()
 
     def _setup_profile(self, profile_auth_by):

--- a/tests/system/datastore/test_aws_s3.py
+++ b/tests/system/datastore/test_aws_s3.py
@@ -99,13 +99,6 @@ class TestAwsS3(TestMLRunSystem):
         )
         register_temporary_client_datastore_profile(profile)
 
-        profile = DatastoreProfileS3(
-            name="s3ds_profile_no_bucket",
-            access_key_id=self._access_key_id,
-            secret_key=self._secret_access_key,
-        )
-        register_temporary_client_datastore_profile(profile)
-
     def custom_teardown(self):
         s3_fs = fsspec.filesystem(
             "s3", key=self._access_key_id, secret=self._secret_access_key

--- a/tests/system/datastore/test_aws_s3.py
+++ b/tests/system/datastore/test_aws_s3.py
@@ -83,11 +83,6 @@ class TestAwsS3(TestMLRunSystem):
                 "",  # no bucket, since it is part of the ds profile
                 object_sub_dir,
             ),
-            "ds_no_bucket": self._make_target_names(
-                "ds://s3ds_profile_no_bucket/",
-                self._bucket_name,
-                object_sub_dir,
-            ),
         }
 
         mlrun.get_or_create_project(self.project_name)
@@ -110,7 +105,7 @@ class TestAwsS3(TestMLRunSystem):
                 s3_fs.rm(file, recursive=True)
             s3_fs.rm(full_path)
 
-    @pytest.mark.parametrize("url_type", ["s3", "ds_with_bucket", "ds_no_bucket"])
+    @pytest.mark.parametrize("url_type", ["s3", "ds_with_bucket"])
     @pytest.mark.parametrize("target_path", ["parquets_url", "parquet_url"])
     def test_ingest_with_parquet_source(self, url_type, target_path):
         #  create source

--- a/tests/system/feature_store/spark_hadoop_test_base.py
+++ b/tests/system/feature_store/spark_hadoop_test_base.py
@@ -100,7 +100,7 @@ class SparkHadoopTestBase(TestMLRunSystem):
 
             # TestMLRunSystem will create this project later in the initialization process, but we need it now
             # to avoid a "project does not exist" error now because the default project was dropped in 1.8.0
-            mlrun.get_or_create_project(cls.project_name)
+            mlrun.get_or_create_project(cls.project_name, allow_cross_project=True)
 
             sj = new_function(
                 kind="remote-spark",

--- a/tests/system/feature_store/spark_hadoop_test_base.py
+++ b/tests/system/feature_store/spark_hadoop_test_base.py
@@ -55,14 +55,13 @@ class SparkHadoopTestBase(TestMLRunSystem):
                 "azure-storage-blob git+https://github.com/mlrun/mlrun.git@development",
             )
         def test_basic_remote_spark_ingest_ds_basic(self):
-            bucket = 'my_bucket'
-            ds_profile = DatastoreProfileBasic(name=self.ds_profile_name)
+            ds_profile = DatastoreProfileBasic(name=self.ds_profile_name, bucket = 'my_bucket')
             register_temporary_client_datastore_profile(ds_profile)
             self.project.register_datastore_profile(ds_profile)
-            self.ds_upload_src(ds_profile, bucket)
+            self.ds_upload_src(ds_profile)
             self.do_test(
-                self.ds_src_path(ds_profile, bucket),
-                self.ds_target_path(ds_profile, bucket),
+                self.ds_src_path(ds_profile),
+                self.ds_target_path(ds_profile),
             )
 
     It is also possible to run the tests locally if you have pyspark installed. To run locally, call
@@ -116,18 +115,14 @@ class SparkHadoopTestBase(TestMLRunSystem):
             get_run_db().delete_function(name=sj.metadata.name)
             cls.spark_image_deployed = True
 
-    def ds_src_path(self, ds_profile, bucket):
-        return f"ds://{ds_profile.name}/{bucket}/bigdata/{self.pq_source}"
+    def ds_src_path(self, ds_profile):
+        return f"ds://{ds_profile.name}/bigdata/{self.pq_source}"
 
-    def ds_target_path(self, ds_profile, bucket):
-        return (
-            f"ds://{ds_profile.name}/{bucket}/bigdata/{self.project_name}/spark_output"
-        )
+    def ds_target_path(self, ds_profile):
+        return f"ds://{ds_profile.name}/bigdata/{self.project_name}/spark_output"
 
-    def ds_upload_src(self, ds_profile, bucket):
-        store, _, _ = store_manager.get_or_create_store(
-            f"ds://{ds_profile.name}/{bucket}"
-        )
+    def ds_upload_src(self, ds_profile):
+        store, _, _ = store_manager.get_or_create_store(f"ds://{ds_profile.name}")
         store.upload(
             f"/bigdata/{self.pq_source}",
             os.path.relpath(str(self.get_assets_path() / self.pq_source)),

--- a/tests/system/feature_store/test_spark_azure.py
+++ b/tests/system/feature_store/test_spark_azure.py
@@ -52,15 +52,15 @@ class TestFeatureStoreAzureSparkEngine(SparkHadoopTestBase):
             client_id=self.env.get("AZURE_STORAGE_CLIENT_ID"),
             client_secret=self.env.get("AZURE_STORAGE_CLIENT_SECRET"),
             sas_token=self.env.get("AZURE_STORAGE_SAS_TOKEN"),
+            container=self.env["AZURE_CONTAINER"],
         )
 
         register_temporary_client_datastore_profile(ds_profile)
         self.project.register_datastore_profile(ds_profile)
 
-        bucket = self.env["AZURE_CONTAINER"]
-        self.ds_upload_src(ds_profile, bucket)
+        self.ds_upload_src(ds_profile)
 
         self.do_test(
-            self.ds_src_path(ds_profile, bucket),
-            self.ds_target_path(ds_profile, bucket),
+            self.ds_src_path(ds_profile),
+            self.ds_target_path(ds_profile),
         )

--- a/tests/system/feature_store/test_spark_engine.py
+++ b/tests/system/feature_store/test_spark_engine.py
@@ -111,12 +111,13 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
                 name="s3ds_profile",
                 access_key=os.environ["AWS_ACCESS_KEY_ID"],
                 secret_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+                bucket=os.environ["AWS_BUCKET_NAME"],
             )
             register_temporary_client_datastore_profile(cls.ds_profile)
-            bucket = os.environ["AWS_BUCKET_NAME"]
-            path = f"ds://{cls.ds_profile.name}/{bucket}"
+
+            path = f"ds://{cls.ds_profile.name}"
             if without_prefix:
-                path = f"{bucket}"
+                path = ""
         else:
             path = "v3io://"
             if without_prefix:

--- a/tests/system/feature_store/test_spark_gcs.py
+++ b/tests/system/feature_store/test_spark_gcs.py
@@ -40,17 +40,18 @@ class TestFeatureStoreGcsSparkEngine(SparkHadoopTestBase):
         cls.configure_image_deployment(Deployment.Remote, "google-cloud-storage")
 
     def test_basic_remote_spark_ingest_ds_gcs(self):
+        bucket = self.env["GCS_BUCKET_NAME"]
         ds_profile = DatastoreProfileGCS(
             name=self.ds_profile_name,
             gcp_credentials=self.env["GCP_CREDENTIALS"],
+            bucket=bucket,
         )
         register_temporary_client_datastore_profile(ds_profile)
         self.project.register_datastore_profile(ds_profile)
 
-        bucket = self.env["GCS_BUCKET_NAME"]
-        self.ds_upload_src(ds_profile, bucket)
+        self.ds_upload_src(ds_profile)
 
         self.do_test(
-            self.ds_src_path(ds_profile, bucket),
-            self.ds_target_path(ds_profile, bucket),
+            self.ds_src_path(ds_profile),
+            self.ds_target_path(ds_profile),
         )

--- a/tests/system/feature_store/test_spark_gcs.py
+++ b/tests/system/feature_store/test_spark_gcs.py
@@ -41,9 +41,12 @@ class TestFeatureStoreGcsSparkEngine(SparkHadoopTestBase):
 
     def test_basic_remote_spark_ingest_ds_gcs(self):
         bucket = self.env["GCS_BUCKET_NAME"]
+        with open(self.env["GOOGLE_APPLICATION_CREDENTIALS"]) as gcs_credentials_path:
+            #  environ expect credentials as string
+            credentials = gcs_credentials_path.read()
         ds_profile = DatastoreProfileGCS(
             name=self.ds_profile_name,
-            gcp_credentials=self.env["GCP_CREDENTIALS"],
+            gcp_credentials=credentials,
             bucket=bucket,
         )
         register_temporary_client_datastore_profile(ds_profile)

--- a/tests/system/feature_store/test_spark_s3.py
+++ b/tests/system/feature_store/test_spark_s3.py
@@ -44,14 +44,14 @@ class TestFeatureStoreS3SparkEngine(SparkHadoopTestBase):
             name=self.ds_profile_name,
             access_key_id=self.env["AWS_ACCESS_KEY_ID"],
             secret_key=self.env["AWS_SECRET_ACCESS_KEY"],
+            bucket=self.env["AWS_BUCKET_NAME"],
         )
         register_temporary_client_datastore_profile(ds_profile)
         self.project.register_datastore_profile(ds_profile)
 
-        bucket = self.env["AWS_BUCKET_NAME"]
-        self.ds_upload_src(ds_profile, bucket)
+        self.ds_upload_src(ds_profile)
 
         self.do_test(
-            self.ds_src_path(ds_profile, bucket),
-            self.ds_target_path(ds_profile, bucket),
+            self.ds_src_path(ds_profile),
+            self.ds_target_path(ds_profile),
         )


### PR DESCRIPTION
Fix Gcs test to be able to run remotely - without credentials file on pod.

## Summary by Sourcery

Fix GCS tests to load credentials from the service account file and parse them as JSON for fsspec and DatastoreProfileGCS, enabling execution on remote pods without a local credentials file

Tests:
- read credentials file content and use json.loads to pass token to fsspec.filesystem in the Google Cloud Storage integration test
- update Spark GCS system test to load credentials from the GOOGLE_APPLICATION_CREDENTIALS file for DatastoreProfileGCS