### PR TITLE
[Datastore] Load gcs creds as string

### DIFF
--- a/tests/integration/google_cloud_storage/test_google_cloud_storage.py
+++ b/tests/integration/google_cloud_storage/test_google_cloud_storage.py
@@ -91,16 +91,11 @@ class TestGoogleCloudStorage:
     def setup_class(cls):
         with open(cls.test_file) as f:
             cls.test_string = f.read()
-        try:
-            credentials = json.loads(cls.credentials_path)
-            token = credentials
-            cls.credentials = cls.credentials_path
-        except json.JSONDecodeError:
-            token = cls.credentials_path
-            with open(cls.credentials_path) as gcs_credentials_path:
-                cls.credentials = gcs_credentials_path.read()
+        with open(cls.credentials_path) as gcs_credentials_path:
+            #  environ expect credentials as string
+            cls.credentials = gcs_credentials_path.read()
 
-        cls._gcs_fs = fsspec.filesystem("gcs", token=token)
+        cls._gcs_fs = fsspec.filesystem("gcs", token=json.loads(cls.credentials))
         cls.clean_test_directory()
 
     def _setup_profile(self, profile_auth_by):

--- a/tests/system/feature_store/test_spark_gcs.py
+++ b/tests/system/feature_store/test_spark_gcs.py
@@ -41,9 +41,12 @@ class TestFeatureStoreGcsSparkEngine(SparkHadoopTestBase):
 
     def test_basic_remote_spark_ingest_ds_gcs(self):
         bucket = self.env["GCS_BUCKET_NAME"]
+        with open(self.env["GOOGLE_APPLICATION_CREDENTIALS"]) as gcs_credentials_path:
+            #  environ expect credentials as string
+            credentials = gcs_credentials_path.read()
         ds_profile = DatastoreProfileGCS(
             name=self.ds_profile_name,
-            gcp_credentials=self.env["GCP_CREDENTIALS"],
+            gcp_credentials=credentials,
             bucket=bucket,
         )
         register_temporary_client_datastore_profile(ds_profile)


### PR DESCRIPTION
## Summary by Sourcery

Simplify GCS credential handling in tests by always reading the credentials file as a string and parsing its JSON content for token usage.

Tests:
- Read GCS credentials file contents as a string in both integration and system tests
- Parse the credentials string with json.loads for fsspec filesystem token
- Pass the read credentials string to DatastoreProfileGCS instead of relying on environment variable or path