### PR TITLE
Feature/ml 12358 code artifact clean

### DIFF
--- a/automation/patch_igz/patch_remote.py
+++ b/automation/patch_igz/patch_remote.py
@@ -49,7 +49,7 @@ class Constants:
     alerts = "mlrun-alerts"
     targets_to_image_name = {
         api: api_container,
-        mlrun: mlrun,
+        mlrun: "mlrun/mlrun",
         mlrun_kfp: mlrun_kfp,
         log_collector: log_collector,
     }

--- a/mlrun/artifacts/__init__.py
+++ b/mlrun/artifacts/__init__.py
@@ -22,6 +22,7 @@ from .base import (
     DirArtifact,
     get_artifact_meta,
 )
+from .code import CodeArtifact, CodeArtifactCodeType, CodeArtifactSpec
 from .dataset import DatasetArtifact, TableArtifact, update_dataset_meta
 from .document import DocumentArtifact, DocumentLoaderSpec, MLRunLoader
 from .llm_prompt import LLMPromptArtifact, LLMPromptArtifactSpec

--- a/mlrun/artifacts/code.py
+++ b/mlrun/artifacts/code.py
@@ -1,0 +1,108 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mlrun.common.types
+
+from .base import Artifact, ArtifactSpec
+
+
+class CodeArtifactCodeType(mlrun.common.types.StrEnum):
+    function = "function"
+    workflow = "workflow"
+
+
+class CodeArtifactSpec(ArtifactSpec):
+    _dict_fields = ArtifactSpec._dict_fields + [
+        "language",
+        "code_type",
+    ]
+
+    def __init__(
+        self,
+        src_path=None,
+        target_path=None,
+        viewer=None,
+        is_inline=False,
+        format=None,
+        size=None,
+        db_key=None,
+        extra_data=None,
+        body=None,
+        language=None,
+        code_type=None,
+    ):
+        super().__init__(
+            src_path=src_path,
+            target_path=target_path,
+            viewer=viewer,
+            is_inline=is_inline,
+            format=format,
+            size=size,
+            db_key=db_key,
+            extra_data=extra_data,
+            body=body,
+        )
+        self.language = language
+        self.code_type = code_type
+
+
+class CodeArtifact(Artifact):
+    """Code Artifact
+
+    Store a code file or archive for use as a function or workflow source.
+    Supports a single code file or a single archive (.zip, .tar.gz).
+    """
+
+    kind = "code"
+
+    def __init__(
+        self,
+        key=None,
+        body=None,
+        format=None,
+        target_path=None,
+        src_path=None,
+        language=None,
+        code_type=None,
+        **kwargs,
+    ):
+        """
+        :param key:          Artifact key
+        :param body:         Inline code content
+        :param format:       Optional file format
+        :param target_path:  Absolute target path
+        :param src_path:     Path to the local code file or archive
+        :param language:     Programming language and version (e.g. "python:3.9")
+        :param code_type:    Type of code: "function" or "workflow" (default: "function")
+        """
+        super().__init__(
+            key,
+            body,
+            format=format,
+            target_path=target_path,
+            src_path=src_path,
+            **kwargs,
+        )
+        self.spec.language = language
+        self.spec.code_type = CodeArtifactCodeType(
+            code_type or CodeArtifactCodeType.function
+        )
+
+    @property
+    def spec(self) -> CodeArtifactSpec:
+        return self._spec
+
+    @spec.setter
+    def spec(self, spec):
+        self._spec = self._verify_dict(spec, "spec", CodeArtifactSpec)

--- a/mlrun/artifacts/code.py
+++ b/mlrun/artifacts/code.py
@@ -26,6 +26,7 @@ class CodeArtifactSpec(ArtifactSpec):
     _dict_fields = ArtifactSpec._dict_fields + [
         "language",
         "code_type",
+        "requirements",
     ]
 
     def __init__(
@@ -41,6 +42,7 @@ class CodeArtifactSpec(ArtifactSpec):
         body=None,
         language=None,
         code_type=None,
+        requirements=None,
     ):
         super().__init__(
             src_path=src_path,
@@ -55,6 +57,7 @@ class CodeArtifactSpec(ArtifactSpec):
         )
         self.language = language
         self.code_type = code_type
+        self.requirements = requirements
 
 
 class CodeArtifact(Artifact):
@@ -75,6 +78,7 @@ class CodeArtifact(Artifact):
         src_path=None,
         language=None,
         code_type=None,
+        requirements=None,
         **kwargs,
     ):
         """
@@ -85,6 +89,7 @@ class CodeArtifact(Artifact):
         :param src_path:     Path to the local code file or archive
         :param language:     Programming language and version (e.g. "python:3.9")
         :param code_type:    Type of code: "function" or "workflow" (default: "function")
+        :param requirements: List of dependency strings (e.g. ["pandas>=2.0", "numpy"])
         """
         super().__init__(
             key,
@@ -98,6 +103,7 @@ class CodeArtifact(Artifact):
         self.spec.code_type = CodeArtifactCodeType(
             code_type or CodeArtifactCodeType.function
         )
+        self.spec.requirements = requirements
 
     @property
     def spec(self) -> CodeArtifactSpec:

--- a/mlrun/artifacts/manager.py
+++ b/mlrun/artifacts/manager.py
@@ -38,6 +38,7 @@ from .base import (
     DirArtifact,
     LinkArtifact,
 )
+from .code import CodeArtifact
 from .dataset import (
     DatasetArtifact,
     TableArtifact,
@@ -62,6 +63,7 @@ artifact_types = {
     "plotly": PlotlyArtifact,
     "document": DocumentArtifact,
     "llm-prompt": LLMPromptArtifact,
+    "code": CodeArtifact,
 }
 
 

--- a/mlrun/common/schemas/artifact.py
+++ b/mlrun/common/schemas/artifact.py
@@ -26,6 +26,7 @@ class ArtifactCategories(mlrun.common.types.StrEnum):
     dataset = "dataset"
     document = "document"
     llm_prompt = "llm-prompt"
+    code = "code"
     other = "other"
 
     # we define the link as a category to prevent import cycles, but it's not a real category
@@ -43,6 +44,8 @@ class ArtifactCategories(mlrun.common.types.StrEnum):
             return [ArtifactCategories.document.value, link_kind], False
         if self.value == ArtifactCategories.llm_prompt.value:
             return [ArtifactCategories.llm_prompt.value, link_kind], False
+        if self.value == ArtifactCategories.code.value:
+            return [ArtifactCategories.code.value, link_kind], False
         if self.value == ArtifactCategories.other.value:
             return (
                 [
@@ -50,6 +53,7 @@ class ArtifactCategories(mlrun.common.types.StrEnum):
                     ArtifactCategories.dataset.value,
                     ArtifactCategories.document.value,
                     ArtifactCategories.llm_prompt.value,
+                    ArtifactCategories.code.value,
                 ],
                 True,
             )
@@ -61,6 +65,7 @@ class ArtifactCategories(mlrun.common.types.StrEnum):
             cls.dataset.value,
             cls.document.value,
             cls.llm_prompt.value,
+            cls.code.value,
         ]:
             return cls(kind)
         return cls.other
@@ -73,6 +78,7 @@ class ArtifactCategories(mlrun.common.types.StrEnum):
             ArtifactCategories.dataset,
             ArtifactCategories.document,
             ArtifactCategories.llm_prompt,
+            ArtifactCategories.code,
         ]
 
 

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -28,6 +28,7 @@ import mlrun.common.formatters
 import mlrun.common.runtimes.constants
 from mlrun.artifacts import (
     Artifact,
+    CodeArtifact,
     DatasetArtifact,
     DocumentArtifact,
     DocumentLoaderSpec,
@@ -806,6 +807,63 @@ class MLClientCtx:
             self._artifacts_manager.log_artifact(
                 self,
                 ds,
+                local_path=local_path,
+                artifact_path=extend_artifact_path(artifact_path, self.artifact_path),
+                target_path=target_path,
+                tag=tag,
+                upload=upload,
+                db_key=db_key,
+                labels=labels,
+            ),
+        )
+        self._update_run()
+        return item
+
+    def log_code_file(
+        self,
+        key,
+        local_path=None,
+        body=None,
+        tag="",
+        artifact_path=None,
+        upload=True,
+        labels=None,
+        target_path="",
+        db_key=None,
+        language=None,
+        code_type: str | mlrun.artifacts.code.CodeArtifactCodeType | None = None,
+        **kwargs,
+    ) -> CodeArtifact:
+        """Log a code artifact and optionally upload it to datastore
+
+        :param key:           Artifact key
+        :param local_path:    Path to the local code file or archive (.zip, .tar.gz)
+        :param body:          Inline code content (string)
+        :param tag:           Version tag
+        :param artifact_path: Target artifact path (when not using the default)
+        :param upload:        Upload to datastore (default is True)
+        :param labels:        A set of key/value labels to tag the artifact with
+        :param target_path:   Absolute target path (instead of using artifact_path + local_path)
+        :param db_key:        The key to use in the artifact DB table
+        :param language:      Programming language and version (e.g. "python:3.9")
+        :param code_type:     Type of code: "function" or "workflow" (default: "function")
+
+        :returns: Code artifact object
+        """
+        code = CodeArtifact(
+            key,
+            body=body,
+            src_path=local_path,
+            language=language,
+            code_type=code_type,
+            **kwargs,
+        )
+
+        item = cast(
+            CodeArtifact,
+            self._artifacts_manager.log_artifact(
+                self,
+                code,
                 local_path=local_path,
                 artifact_path=extend_artifact_path(artifact_path, self.artifact_path),
                 target_path=target_path,

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -832,6 +832,7 @@ class MLClientCtx:
         db_key=None,
         language=None,
         code_type: str | mlrun.artifacts.code.CodeArtifactCodeType | None = None,
+        requirements: list[str] | None = None,
         **kwargs,
     ) -> CodeArtifact:
         """Log a code artifact and optionally upload it to datastore
@@ -847,6 +848,7 @@ class MLClientCtx:
         :param db_key:        The key to use in the artifact DB table
         :param language:      Programming language and version (e.g. "python:3.9")
         :param code_type:     Type of code: "function" or "workflow" (default: "function")
+        :param requirements:  List of dependency strings (e.g. ["pandas>=2.0", "numpy"])
 
         :returns: Code artifact object
         """
@@ -856,6 +858,7 @@ class MLClientCtx:
             src_path=local_path,
             language=language,
             code_type=code_type,
+            requirements=requirements,
             **kwargs,
         )
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -82,6 +82,7 @@ from mlrun_pipelines.models import PipelineNodeWrapper
 from ..artifacts import (
     Artifact,
     ArtifactProducer,
+    CodeArtifact,
     DatasetArtifact,
     DocumentArtifact,
     DocumentLoaderSpec,
@@ -1772,6 +1773,59 @@ class MlrunProject(ModelObj):
             DatasetArtifact,
             self.log_artifact(
                 ds,
+                local_path=local_path,
+                artifact_path=artifact_path,
+                target_path=target_path,
+                tag=tag,
+                upload=upload,
+                labels=labels,
+            ),
+        )
+        return item
+
+    def log_code_file(
+        self,
+        key,
+        local_path=None,
+        body=None,
+        tag="",
+        artifact_path=None,
+        upload=None,
+        labels=None,
+        target_path="",
+        language=None,
+        code_type: str | mlrun.artifacts.code.CodeArtifactCodeType | None = None,
+        **kwargs,
+    ) -> CodeArtifact:
+        """
+        Log a code artifact and optionally upload it to datastore.
+
+        :param key:           artifact key
+        :param local_path:    path to the local code file or archive (.zip, .tar.gz)
+        :param body:          inline code content (string)
+        :param tag:           version tag
+        :param artifact_path: target artifact path (when not using the default)
+        :param upload:        upload to datastore (default is True)
+        :param labels:        a set of key/value labels to tag the artifact with
+        :param target_path:   absolute target path (instead of using artifact_path + local_path)
+        :param language:      programming language and version (e.g. "python:3.9")
+        :param code_type:     type of code: "function" or "workflow" (default: "function")
+
+        :returns: code artifact object
+        """
+        code = CodeArtifact(
+            key,
+            body=body,
+            src_path=local_path,
+            language=language,
+            code_type=code_type,
+            **kwargs,
+        )
+
+        item = cast(
+            CodeArtifact,
+            self.log_artifact(
+                code,
                 local_path=local_path,
                 artifact_path=artifact_path,
                 target_path=target_path,

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1795,6 +1795,7 @@ class MlrunProject(ModelObj):
         target_path="",
         language=None,
         code_type: str | mlrun.artifacts.code.CodeArtifactCodeType | None = None,
+        requirements: list[str] | None = None,
         **kwargs,
     ) -> CodeArtifact:
         """
@@ -1810,6 +1811,7 @@ class MlrunProject(ModelObj):
         :param target_path:   absolute target path (instead of using artifact_path + local_path)
         :param language:      programming language and version (e.g. "python:3.9")
         :param code_type:     type of code: "function" or "workflow" (default: "function")
+        :param requirements:  list of dependency strings (e.g. ["pandas>=2.0", "numpy"])
 
         :returns: code artifact object
         """
@@ -1819,6 +1821,7 @@ class MlrunProject(ModelObj):
             src_path=local_path,
             language=language,
             code_type=code_type,
+            requirements=requirements,
             **kwargs,
         )
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -48,6 +48,7 @@ import mlrun.common.schemas.artifact
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
 import mlrun.common.schemas.notification
 import mlrun.common.secrets
+import mlrun.datastore
 import mlrun.datastore.datastore_profile
 import mlrun.db
 import mlrun.errors
@@ -6087,6 +6088,22 @@ def _init_function_from_dict(
         func = new_function(
             name, image=image, kind=kind or "job", handler=handler, tag=tag
         )
+
+    elif mlrun.datastore.is_store_uri(url):
+        # store:// artifact URI — store as-is in spec.build.source, resolve at run/deploy time
+        if with_repo:
+            raise ValueError(
+                "with_repo=True is not supported with store:// artifact URIs. "
+                "The artifact already provides the code source."
+            )
+        func = new_function(
+            name,
+            image=image,
+            kind=kind or "job",
+            handler=handler,
+            tag=tag,
+        )
+        func.spec.build.source = url
 
     elif is_yaml_path(url) or url.startswith("db://") or url.startswith("hub://"):
         func = import_function(url, new_name=name)

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -6124,9 +6124,7 @@ def _download_store_artifact_for_export(
         path_hash = hashlib.sha256(target_path.encode()).hexdigest()[:8]
         name, ext = os.path.splitext(filename)
         unique_filename = f"{name}_{path_hash}{ext}"
-        local_path = os.path.join(
-            project_context, ".mlrun", "code", unique_filename
-        )
+        local_path = os.path.join(project_context, ".mlrun", "code", unique_filename)
         os.makedirs(os.path.dirname(local_path), exist_ok=True)
         mlrun.get_dataitem(target_path).download(local_path)
         return os.path.relpath(local_path, project_context)

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -16,6 +16,7 @@ import contextlib
 import datetime
 import getpass
 import glob
+import hashlib
 import http
 import importlib.util as imputil
 import json
@@ -3968,8 +3969,50 @@ class MlrunProject(ModelObj):
 
         project_dir = pathlib.Path(project_file_path).parent
         project_dir.mkdir(parents=True, exist_ok=True)
-        with open(project_file_path, "w") as fp:
-            fp.write(self.to_yaml())
+
+        # For zip exports, download store:// function code into the project
+        # context and temporarily rewrite function definitions to use local
+        # paths so the exported project.yaml references files inside the zip.
+        original_sources: dict[str, str] = {}
+        if archive_code:
+            for name, func_def in self.spec._function_definitions.items():
+                store_uri = None
+                if isinstance(func_def, dict):
+                    source = func_def.get("url", "")
+                    if source and mlrun.datastore.is_store_uri(source):
+                        store_uri = source
+                elif hasattr(func_def, "spec") and hasattr(func_def.spec, "build"):
+                    source = getattr(func_def.spec.build, "source", "")
+                    if source and mlrun.datastore.is_store_uri(source):
+                        store_uri = source
+
+                if store_uri:
+                    relative_path = _download_store_artifact_for_export(
+                        project_context=str(project_dir),
+                        store_uri=store_uri,
+                        project_name=self.metadata.name,
+                    )
+                    if relative_path:
+                        original_sources[name] = store_uri
+                        if isinstance(func_def, dict):
+                            func_def["url"] = relative_path
+                        elif hasattr(func_def, "spec"):
+                            func_def.spec.build.source = relative_path
+
+        try:
+            with open(project_file_path, "w") as fp:
+                fp.write(self.to_yaml())
+        finally:
+            # Restore original store:// refs so in-memory state is never corrupted,
+            # even if to_yaml() or the file write raises an exception
+            for name, original_source in original_sources.items():
+                func_def = self.spec._function_definitions.get(name)
+                if not func_def:
+                    continue
+                if isinstance(func_def, dict):
+                    func_def["url"] = original_source
+                elif hasattr(func_def, "spec"):
+                    func_def.spec.build.source = original_source
 
         if archive_code:
             files_filter = include_files or "**"
@@ -3978,7 +4021,9 @@ class MlrunProject(ModelObj):
                 fpath = f.name if remote_file else filepath
                 with zipfile.ZipFile(fpath, "w") as zipf:
                     for file_path in glob.iglob(
-                        f"{project_dir}/{files_filter}", recursive=True
+                        f"{project_dir}/{files_filter}",
+                        recursive=True,
+                        include_hidden=True,
                     ):
                         write_path = pathlib.Path(file_path)
                         zipf.write(
@@ -6056,6 +6101,42 @@ class MlrunProject(ModelObj):
 def _set_as_current_active_project(project: MlrunProject):
     mlrun.mlconf.active_project = project.metadata.name
     pipeline_context.set(project)
+
+
+def _download_store_artifact_for_export(
+    project_context: str,
+    store_uri: str,
+    project_name: str,
+) -> str | None:
+    """Download a store:// artifact's content into the project context for zip export.
+
+    :param project_context: Project context directory
+    :param store_uri:       The store:// URI
+    :param project_name:    Project name
+    :returns: Relative path of the downloaded file, or None on failure
+    """
+    try:
+        artifact = mlrun.datastore.get_store_resource(store_uri, project=project_name)
+        target_path = artifact.get_target_path()
+        filename = os.path.basename(target_path)
+        # Avoid collisions when different artifacts share the same filename
+        # (e.g. s3://bucket-a/funcs/handler.py vs s3://bucket-b/other/handler.py)
+        path_hash = hashlib.sha256(target_path.encode()).hexdigest()[:8]
+        name, ext = os.path.splitext(filename)
+        unique_filename = f"{name}_{path_hash}{ext}"
+        local_path = os.path.join(
+            project_context, ".mlrun", "code", unique_filename
+        )
+        os.makedirs(os.path.dirname(local_path), exist_ok=True)
+        mlrun.get_dataitem(target_path).download(local_path)
+        return os.path.relpath(local_path, project_context)
+    except Exception:
+        logger.warning(
+            "Failed to download code artifact for export",
+            store_uri=store_uri,
+            project=project_name,
+        )
+        return None
 
 
 def _init_function_from_dict(

--- a/mlrun/runtimes/local.py
+++ b/mlrun/runtimes/local.py
@@ -254,6 +254,7 @@ class LocalRuntime(BaseRuntime, ParallelRunner):
                 self.spec.build.source,
                 self.spec.build.source_code_target_dir,
                 secrets=execution._secrets_manager,
+                project=self.metadata.project,
             )
             if workdir and not workdir.startswith("/"):
                 execution._current_workdir = os.path.join(target_dir, workdir)

--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -1165,11 +1165,13 @@ class ApplicationRuntime(nuclio_function.RemoteRuntime):
             project=project_name,
         )
 
-        # Upload the file as an artifact to an internal path with system-generated label
+        # Upload the file as a code artifact to an internal path with system-generated label
         try:
-            artifact = project.log_artifact(
-                item=artifact_key,
+            artifact = project.log_code_file(
+                key=artifact_key,
                 local_path=source,
+                language="python",
+                code_type="function",
                 artifact_path=mlrun.common.constants.MLRUN_INTERNAL_ARTIFACT_PATH,
                 upload=True,
                 labels={

--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -246,9 +246,9 @@ class ApplicationStatus(nuclio_function.NuclioStatus):
             external_invocation_urls=external_invocation_urls,
             build_pod=build_pod,
             container_image=container_image,
+            application_source=application_source,
         )
         self.application_image = application_image or None
-        self.application_source = application_source or None
         self.sidecar_name = sidecar_name or None
         self.api_gateway_name = api_gateway_name or None
         self.api_gateway: nuclio_api_gateway.APIGateway | None = api_gateway or None

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -271,6 +271,7 @@ class NuclioStatus(FunctionStatus):
         external_invocation_urls=None,
         build_pod=None,
         container_image=None,
+        application_source=None,
     ):
         super().__init__(state, build_pod)
 
@@ -287,6 +288,11 @@ class NuclioStatus(FunctionStatus):
 
         # the name of the image that was built and pushed to the registry, and used by the nuclio function
         self.container_image = container_image
+
+        # Preserves the original store:// source URI across re-deployments.
+        # When a function is redeployed via from_image(), spec.build.source is cleared;
+        # this field allows _should_fetch_source_code() to detect store:// sources on redeploy.
+        self.application_source = application_source or None
 
 
 class RemoteRuntime(KubeResource):

--- a/mlrun/utils/clones.py
+++ b/mlrun/utils/clones.py
@@ -191,9 +191,20 @@ def clone_git(url: str, context: str, secrets=None, clone: bool = True):
     return url, repo
 
 
-def extract_source(source: str, workdir=None, secrets=None, clone=True):
+def extract_source(source: str, workdir=None, secrets=None, clone=True, project=None):
     if not source:
         return
+    # Handle store:// artifact URIs by delegating to load_source_code
+    # Import here to avoid circular import (clones is imported from mlrun.utils.__init__)
+    import mlrun.datastore
+
+    if mlrun.datastore.is_store_uri(source):
+        target_dir = workdir or os.path.realpath("./code")
+        return load_source_code(
+            source_uri=source,
+            target_dir=target_dir,
+            project=project,
+        )
     clone = clone if workdir else False
     target_dir = workdir or os.path.realpath("./code")
     if source.endswith(".zip"):

--- a/mlrun/utils/clones.py
+++ b/mlrun/utils/clones.py
@@ -311,7 +311,9 @@ def _load_store_artifact(
             f"Failed to download artifact from {artifact_target_path} to {local_file_path}"
         ) from exc
 
-    return local_file_path
+    # Return the directory (not the file path) so that callers like _pre_run()
+    # can set it as the working directory and add it to sys.path for imports.
+    return target_dir
 
 
 def _load_git_source(source_uri: str, target_dir: str) -> str:

--- a/server/py/services/api/crud/runtimes/nuclio/function.py
+++ b/server/py/services/api/crud/runtimes/nuclio/function.py
@@ -298,12 +298,27 @@ def _compile_function_config(
             function.status.application_source = source
             function.spec.build.source = ""
 
-            # After clearing spec.build.source, the condition further down
-            # (base_spec or functionSourceCode or source or serving) may all be falsy
-            # for vanilla nuclio, causing it to fall into nuclio.build_file() which fails.
-            # Ensure base_spec is set so the function takes the config path.
+            # Set base_spec so _compile_function_config takes the config path
+            # (not the build_file path which would fail without a source file).
             if not function.spec.base_spec:
                 function.spec.base_spec = nuclio.config.new_config()
+
+            # Set a wrapper as functionSourceCode that re-exports the handler
+            # from the init-container-loaded code (via PYTHONPATH).
+            # This lets Nuclio build normally using the base image.
+            handler_str = function.spec.function_handler or "main:handler"
+            if ":" in handler_str:
+                module_name, func_name = handler_str.split(":", 1)
+            else:
+                module_name, func_name = handler_str, "handler"
+            wrapper = f"from {module_name} import {func_name} as handler\n"
+            import base64
+
+            function.spec.build.functionSourceCode = base64.b64encode(
+                wrapper.encode("utf-8")
+            ).decode("utf-8")
+            # Override handler to point to the wrapper module
+            function.spec.function_handler = "handler:handler"
 
             _configure_source_loader_init_container(
                 function,
@@ -933,8 +948,16 @@ def _build_source_loader_init_container(
     """
     project = function.metadata.project
 
+    # Use the function's image for the init container if available,
+    # otherwise fall back to the default base image. The function image
+    # already has the MLRun SDK and avoids registry path mismatches.
+    init_image_base = (
+        function.spec.image
+        or function.spec.build.base_image
+        or mlrun.mlconf.default_base_image
+    )
     init_container_image = services.api.utils.builder.resolve_and_enrich_image_target(
-        mlrun.mlconf.default_base_image,
+        init_image_base,
         client_version=client_version,
         client_python_version=client_python_version,
     )

--- a/server/py/services/api/crud/runtimes/nuclio/function.py
+++ b/server/py/services/api/crud/runtimes/nuclio/function.py
@@ -269,19 +269,39 @@ def _compile_function_config(
                 )
             )
 
-    # Configure init container for Application runtime when source needs runtime loading
-    if function.kind == mlrun.runtimes.RuntimeKinds.application:
-        if not sidecars:
-            raise mlrun.errors.MLRunInvalidArgumentError(
-                f"No sidecar found for Application runtime '{function.metadata.name}'. "
-                "Application runtime requires a sidecar container to run the user's application. "
-                "Ensure the application image is set via 'spec.image' or 'with_sidecar()'."
-            )
-        if _should_fetch_source_code(function):
+    # Configure init container when source needs runtime loading
+    # (store:// URIs, git with pull_at_runtime, etc.)
+    if _should_fetch_source_code(function):
+        if function.kind == mlrun.runtimes.RuntimeKinds.application:
+            if not sidecars:
+                raise mlrun.errors.MLRunInvalidArgumentError(
+                    f"No sidecar found for Application runtime '{function.metadata.name}'. "
+                    "Application runtime requires a sidecar container to run the user's application. "
+                    "Ensure the application image is set via 'spec.image' or 'with_sidecar()'."
+                )
             _configure_source_loader_init_container(
                 function,
                 # Application runtime has exactly one sidecar (the user's application container)
-                sidecar=sidecars[0],
+                container=sidecars[0],
+                client_version=client_version,
+                client_python_version=client_python_version,
+            )
+        else:
+            # Vanilla Nuclio/Serving: save store:// URI, clear source to skip Nuclio builder
+            source = function.spec.build.source
+            function.status.application_source = source
+            function.spec.build.source = ""
+
+            # After clearing spec.build.source, the condition further down
+            # (base_spec or functionSourceCode or source or serving) may all be falsy
+            # for vanilla nuclio, causing it to fall into nuclio.build_file() which fails.
+            # Ensure base_spec is set so the function takes the config path.
+            if not function.spec.base_spec:
+                function.spec.base_spec = nuclio.config.new_config()
+
+            _configure_source_loader_init_container(
+                function,
+                container=None,  # patch main function container, not a sidecar
                 client_version=client_version,
                 client_python_version=client_python_version,
             )
@@ -800,26 +820,32 @@ def _should_fetch_source_code(
 
 def _configure_source_loader_init_container(
     function: mlrun.runtimes.nuclio.function.RemoteRuntime,
-    sidecar: dict,
+    container: dict | None = None,
     client_version: str | None = None,
     client_python_version: str | None = None,
 ):
     """
-    Configure an init container for Application runtime to load source code at runtime.
+    Configure an init container to load source code at runtime.
 
-    This function sets up a Kubernetes init container that runs before the main sidecar
+    This function sets up a Kubernetes init container that runs before the main
     container starts. The init container is responsible for fetching source code from
     remote locations (store:// URIs, git repos, archives) and extracting it to a shared
-    volume that the sidecar can access.
+    volume that the target container can access.
 
     The setup involves:
-    1. Creating an emptyDir volume shared between init container and sidecar
+    1. Creating an emptyDir volume shared between init container and target container
     2. Building an init container spec that runs `mlrun load-source` command
     3. Adding the init container to the function's Nuclio spec
-    4. Patching the sidecar to mount the shared volume and set PYTHONPATH
+    4. Patching the target container to mount the shared volume and set PYTHONPATH
+
+    When ``container`` is provided (Application runtime), it is patched directly with
+    the volume mount, workingDir, and PYTHONPATH.  When ``container`` is None (vanilla
+    Nuclio/Serving), PYTHONPATH is injected via ``function.spec.config`` (Nuclio CRD
+    env vars) and the volume mount is handled by ``function.spec.with_volume_mounts()``.
 
     :param function: The function object to configure
-    :param sidecar: The sidecar container dict (the user's application container)
+    :param container: The target container dict to patch (e.g. sidecar). When None,
+        the main Nuclio function container is patched instead.
     :param client_version: Client version for resolving the init container image
     :param client_python_version: Client Python version for resolving the init container image
     """
@@ -837,7 +863,7 @@ def _configure_source_loader_init_container(
     volume = {"name": volume_name, "emptyDir": {}}
     volume_mount = {"name": volume_name, "mountPath": target_dir}
 
-    # Add volume to function spec so both init container and sidecar can access it
+    # Add volume to function spec so both init container and target container can access it
     function.spec.with_volumes(volume)
     function.spec.with_volume_mounts(volume_mount)
 
@@ -854,13 +880,21 @@ def _configure_source_loader_init_container(
     # Add init container to function spec (idempotently - replaces if exists)
     _ensure_source_loader_init_container(function, init_container)
 
-    _patch_sidecar_for_source(
-        sidecar=sidecar,
-        volume_name=volume_name,
-        volume_mount=volume_mount,
-        target_dir=target_dir,
-        workdir=workdir,
-    )
+    if container is not None:
+        _patch_container_for_source(
+            container=container,
+            volume_name=volume_name,
+            volume_mount=volume_mount,
+            target_dir=target_dir,
+            workdir=workdir,
+        )
+    else:
+        # For vanilla Nuclio/serving: patch the main function container
+        _patch_main_function_container(
+            function=function,
+            target_dir=target_dir,
+            workdir=workdir,
+        )
 
     logger.debug(
         "Configured source loader init container",
@@ -940,30 +974,30 @@ def _ensure_source_loader_init_container(
         init_containers.append(init_container)
 
 
-def _patch_sidecar_for_source(
-    sidecar: dict,
+def _patch_container_for_source(
+    container: dict,
     volume_name: str,
     volume_mount: dict,
     target_dir: str,
     workdir: str | None = None,
 ):
     """
-    Patch sidecar container with volume mount, workingDir, and PYTHONPATH.
+    Patch container with volume mount, workingDir, and PYTHONPATH.
 
-    :param sidecar: The sidecar container dict
+    :param container: The container dict (e.g. sidecar or main function container)
     :param volume_name: Name of the source volume
     :param volume_mount: Volume mount configuration
     :param target_dir: Target directory where source code is extracted
     :param workdir: Working directory relative to target_dir (e.g. 'subdir') or absolute path
-                    on the container filesystem. When set, the sidecar runs from this directory
+                    on the container filesystem. When set, the container runs from this directory
                     instead of the target_dir root.
     """
     # Add volume mount idempotently
-    sidecar_mounts = sidecar.setdefault("volumeMounts", [])
-    if not any(vm.get("name") == volume_name for vm in sidecar_mounts):
-        sidecar_mounts.append(volume_mount)
+    container_mounts = container.setdefault("volumeMounts", [])
+    if not any(vm.get("name") == volume_name for vm in container_mounts):
+        container_mounts.append(volume_mount)
 
-    # Resolve the effective working directory for the sidecar.
+    # Resolve the effective working directory for the container.
     # workdir can be relative (joined with target_dir) or absolute (used as-is).
     if workdir:
         if os.path.isabs(workdir):
@@ -973,13 +1007,13 @@ def _patch_sidecar_for_source(
     else:
         resolved_workdir = target_dir
 
-    sidecar["workingDir"] = resolved_workdir
+    container["workingDir"] = resolved_workdir
 
-    # Set PYTHONPATH so the sidecar can import modules from the source directory.
+    # Set PYTHONPATH so the container can import modules from the source directory.
     # If PYTHONPATH already exists (user-defined), prepend our path to preserve theirs.
-    sidecar_env = sidecar.setdefault("env", [])
+    container_env = container.setdefault("env", [])
     pythonpath_env = next(
-        (e for e in sidecar_env if e.get("name") == "PYTHONPATH"), None
+        (e for e in container_env if e.get("name") == "PYTHONPATH"), None
     )
     if pythonpath_env:
         existing_path = pythonpath_env.get("value", "")
@@ -990,4 +1024,46 @@ def _patch_sidecar_for_source(
                 else resolved_workdir
             )
     else:
-        sidecar_env.append({"name": "PYTHONPATH", "value": resolved_workdir})
+        container_env.append({"name": "PYTHONPATH", "value": resolved_workdir})
+
+
+def _patch_main_function_container(
+    function: mlrun.runtimes.nuclio.function.RemoteRuntime,
+    target_dir: str,
+    workdir: str | None = None,
+):
+    """
+    Patch the main Nuclio function container with PYTHONPATH.
+
+    Unlike sidecars (which are plain dicts), the main container's properties
+    are injected via function.spec.config which feeds directly into the Nuclio CRD.
+    Volume mounts are already handled by function.spec.with_volume_mounts()
+    (called by the parent function).
+
+    :param function: The function object to configure
+    :param target_dir: Target directory where source code is extracted
+    :param workdir: Working directory relative to target_dir or absolute path
+    """
+    if workdir:
+        if os.path.isabs(workdir):
+            resolved_workdir = workdir
+        else:
+            resolved_workdir = os.path.join(target_dir, workdir)
+    else:
+        resolved_workdir = target_dir
+
+    # Inject PYTHONPATH directly into the Nuclio config spec.
+    # We use function.spec.config (not function.spec.env) because
+    # _resolve_env_vars() has already run by the time this is called.
+    env_list = function.spec.config.setdefault("spec.env", [])
+    pythonpath_env = next((e for e in env_list if e.get("name") == "PYTHONPATH"), None)
+    if pythonpath_env:
+        existing_path = pythonpath_env.get("value", "")
+        if resolved_workdir not in existing_path.split(":"):
+            pythonpath_env["value"] = (
+                f"{resolved_workdir}:{existing_path}"
+                if existing_path
+                else resolved_workdir
+            )
+    else:
+        env_list.append({"name": "PYTHONPATH", "value": resolved_workdir})

--- a/server/py/services/api/crud/runtimes/nuclio/function.py
+++ b/server/py/services/api/crud/runtimes/nuclio/function.py
@@ -270,14 +270,18 @@ def _compile_function_config(
                 )
             )
 
-    # Configure init container when source needs runtime loading
-    # (store:// URIs, git with pull_at_runtime, etc.)
-    if _should_fetch_source_code(function):
-        # Merge artifact requirements into function build spec (all runtime kinds)
+    # For store:// sources, merge artifact requirements into build spec (both modes)
+    source = function.spec.build.source or getattr(
+        function.status, "application_source", None
+    )
+    if source and mlrun.datastore.is_store_uri(source):
         services.api.utils.functions.enrich_function_from_code_artifact(
             function, project
         )
 
+    # Configure init container when source needs runtime loading
+    # (store://, git, archive with load_source_on_run=True)
+    if _should_fetch_source_code(function):
         if function.kind == mlrun.runtimes.RuntimeKinds.application:
             if not sidecars:
                 raise mlrun.errors.MLRunInvalidArgumentError(
@@ -287,7 +291,6 @@ def _compile_function_config(
                 )
             _configure_source_loader_init_container(
                 function,
-                # Application runtime has exactly one sidecar (the user's application container)
                 container=sidecars[0],
                 client_version=client_version,
                 client_python_version=client_python_version,
@@ -298,14 +301,11 @@ def _compile_function_config(
             function.status.application_source = source
             function.spec.build.source = ""
 
-            # Set base_spec so _compile_function_config takes the config path
-            # (not the build_file path which would fail without a source file).
             if not function.spec.base_spec:
                 function.spec.base_spec = nuclio.config.new_config()
 
             # Set a wrapper as functionSourceCode that re-exports the handler
             # from the init-container-loaded code (via PYTHONPATH).
-            # This lets Nuclio build normally using the base image.
             handler_str = function.spec.function_handler or "main:handler"
             if ":" in handler_str:
                 module_name, func_name = handler_str.split(":", 1)
@@ -317,15 +317,30 @@ def _compile_function_config(
             function.spec.build.functionSourceCode = base64.b64encode(
                 wrapper.encode("utf-8")
             ).decode("utf-8")
-            # Override handler to point to the wrapper module
             function.spec.function_handler = "handler:handler"
 
             _configure_source_loader_init_container(
                 function,
-                container=None,  # patch main function container, not a sidecar
+                container=None,
                 client_version=client_version,
                 client_python_version=client_python_version,
             )
+
+    # Build-time resolution for store:// sources (load_source_on_run=False)
+    elif source and mlrun.datastore.is_store_uri(source):
+        import base64
+
+        code_content = services.api.utils.functions.resolve_code_artifact_content(
+            source, project
+        )
+        function.spec.build.functionSourceCode = base64.b64encode(
+            code_content.encode("utf-8")
+        ).decode("utf-8")
+        # Clear build.source so Nuclio builder doesn't try to resolve store://
+        function.status.application_source = function.spec.build.source
+        function.spec.build.source = ""
+        if not function.spec.base_spec:
+            function.spec.base_spec = nuclio.config.new_config()
 
     nuclio_spec = nuclio.ConfigSpec(
         env=env_dict,
@@ -828,15 +843,12 @@ def _should_fetch_source_code(
     if not source:
         return False
 
-    # Store artifact URIs always need init container
-    if mlrun.datastore.is_store_uri(source):
-        return True
-
+    is_store_source = mlrun.datastore.is_store_uri(source)
     is_git_source = source.startswith("git://")
     is_archive_source = source.endswith(".tar.gz") or source.endswith(".zip")
-    pull_at_runtime = function.spec.build.load_source_on_run
+    pull_at_runtime = bool(function.spec.build.load_source_on_run)
 
-    return (is_git_source or is_archive_source) and pull_at_runtime
+    return (is_store_source or is_git_source or is_archive_source) and pull_at_runtime
 
 
 def _configure_source_loader_init_container(

--- a/server/py/services/api/crud/runtimes/nuclio/function.py
+++ b/server/py/services/api/crud/runtimes/nuclio/function.py
@@ -40,6 +40,7 @@ import framework.utils.singletons.k8s
 import services.api.crud.runtimes.nuclio.helpers
 import services.api.runtime_handlers
 import services.api.utils.builder
+import services.api.utils.functions
 from services.api.crud.runtimes.nuclio.helpers import pure_nuclio_deployed_restricted
 
 
@@ -272,6 +273,11 @@ def _compile_function_config(
     # Configure init container when source needs runtime loading
     # (store:// URIs, git with pull_at_runtime, etc.)
     if _should_fetch_source_code(function):
+        # Merge artifact requirements into function build spec (all runtime kinds)
+        services.api.utils.functions.enrich_function_from_code_artifact(
+            function, project
+        )
+
         if function.kind == mlrun.runtimes.RuntimeKinds.application:
             if not sidecars:
                 raise mlrun.errors.MLRunInvalidArgumentError(

--- a/server/py/services/api/launcher.py
+++ b/server/py/services/api/launcher.py
@@ -44,6 +44,7 @@ import framework.utils.helpers
 import framework.utils.singletons.db
 import services.api.crud
 import services.api.runtime_handlers
+import services.api.utils.functions
 import services.api.utils.helpers
 
 # Configmap objects on Kubernetes have 10Mb size limit
@@ -239,6 +240,13 @@ class ServerSideLauncher(launcher.BaseLauncher):
             mlrun.projects.pipelines.enrich_function_object(
                 project, runtime, copy_function=False, try_auto_mount=False
             )
+
+        # Merge code artifact requirements into function build spec.
+        # Must happen before requires_build() so the build decision
+        # accounts for artifact requirements.
+        services.api.utils.functions.enrich_function_from_code_artifact(
+            runtime, runtime.metadata.project
+        )
 
         if (
             not runtime.spec.image

--- a/server/py/services/api/runtime_handlers/kubejob.py
+++ b/server/py/services/api/runtime_handlers/kubejob.py
@@ -22,6 +22,7 @@ from packaging.version import parse as parse_version
 import mlrun
 import mlrun.common.constants as mlrun_constants
 import mlrun.common.schemas
+import mlrun.datastore
 import mlrun.errors
 from mlrun.runtimes.base import RuntimeClassMode
 from mlrun.utils import logger
@@ -121,6 +122,12 @@ class KubeRuntimeHandler(BaseRuntimeHandler):
 
         if code:
             extra_env.append({"name": "MLRUN_EXEC_CODE", "value": code})
+
+        # store:// artifact URIs must always be loaded at runtime (pod can't resolve at build time)
+        if runtime.spec.build.source and mlrun.datastore.is_store_uri(
+            runtime.spec.build.source
+        ):
+            runtime.spec.build.load_source_on_run = True
 
         load_archive = (
             runtime.spec.build.load_source_on_run and runtime.spec.build.source

--- a/server/py/services/api/runtime_handlers/kubejob.py
+++ b/server/py/services/api/runtime_handlers/kubejob.py
@@ -123,9 +123,12 @@ class KubeRuntimeHandler(BaseRuntimeHandler):
         if code:
             extra_env.append({"name": "MLRUN_EXEC_CODE", "value": code})
 
-        # store:// artifact URIs must always be loaded at runtime (pod can't resolve at build time)
-        if runtime.spec.build.source and mlrun.datastore.is_store_uri(
+        # store:// artifact URIs default to runtime loading for jobs
+        # (pod resolves at startup via extract_source → load_source_code)
+        if (
             runtime.spec.build.source
+            and mlrun.datastore.is_store_uri(runtime.spec.build.source)
+            and not runtime.spec.build.load_source_on_run
         ):
             runtime.spec.build.load_source_on_run = True
 

--- a/server/py/services/api/tests/unit/crud/runtimes/nuclio/test_helpers.py
+++ b/server/py/services/api/tests/unit/crud/runtimes/nuclio/test_helpers.py
@@ -162,3 +162,32 @@ def test_resolve_nuclio_runtime_python_image(
             mlrun_client_version, python_version
         )
     )
+
+
+def test_nuclio_store_uri_should_fetch_source():
+    """_should_fetch_source_code returns True for nuclio with store:// source."""
+    func = mlrun.new_function("test-func", kind="nuclio")
+    func.metadata.project = "test-proj"
+    func.spec.build.source = "store://artifacts/test-proj/my_code"
+
+    assert (
+        services.api.crud.runtimes.nuclio.function._should_fetch_source_code(func)
+        is True
+    )
+
+
+def test_nuclio_store_source_preserved_on_redeploy():
+    """status.application_source preserves store:// URI across re-deploys."""
+    func = mlrun.new_function("test-func", kind="nuclio")
+    func.metadata.project = "test-proj"
+    func.spec.build.source = "store://artifacts/test-proj/my_code"
+
+    # Simulate first deploy: source saved, then cleared
+    func.status.application_source = func.spec.build.source
+    func.spec.build.source = ""
+
+    # On redeploy, _should_fetch_source_code falls back to status.application_source
+    assert (
+        services.api.crud.runtimes.nuclio.function._should_fetch_source_code(func)
+        is True
+    )

--- a/server/py/services/api/tests/unit/crud/runtimes/nuclio/test_helpers.py
+++ b/server/py/services/api/tests/unit/crud/runtimes/nuclio/test_helpers.py
@@ -164,11 +164,25 @@ def test_resolve_nuclio_runtime_python_image(
     )
 
 
-def test_nuclio_store_uri_should_fetch_source():
-    """_should_fetch_source_code returns True for nuclio with store:// source."""
+def test_nuclio_store_uri_should_not_fetch_source_by_default():
+    """_should_fetch_source_code returns False for store:// when load_source_on_run=False (default)."""
     func = mlrun.new_function("test-func", kind="nuclio")
     func.metadata.project = "test-proj"
     func.spec.build.source = "store://artifacts/test-proj/my_code"
+
+    # Default: load_source_on_run=False → build-time resolution, no init container
+    assert (
+        services.api.crud.runtimes.nuclio.function._should_fetch_source_code(func)
+        is False
+    )
+
+
+def test_nuclio_store_uri_should_fetch_source_when_runtime_mode():
+    """_should_fetch_source_code returns True for store:// with load_source_on_run=True."""
+    func = mlrun.new_function("test-func", kind="nuclio")
+    func.metadata.project = "test-proj"
+    func.spec.build.source = "store://artifacts/test-proj/my_code"
+    func.spec.build.load_source_on_run = True
 
     assert (
         services.api.crud.runtimes.nuclio.function._should_fetch_source_code(func)
@@ -181,6 +195,7 @@ def test_nuclio_store_source_preserved_on_redeploy():
     func = mlrun.new_function("test-func", kind="nuclio")
     func.metadata.project = "test-proj"
     func.spec.build.source = "store://artifacts/test-proj/my_code"
+    func.spec.build.load_source_on_run = True
 
     # Simulate first deploy: source saved, then cleared
     func.status.application_source = func.spec.build.source

--- a/server/py/services/api/tests/unit/runtime_handlers/test_kubejob.py
+++ b/server/py/services/api/tests/unit/runtime_handlers/test_kubejob.py
@@ -22,6 +22,8 @@ from sqlalchemy.orm import Session
 
 import mlrun.common.constants as mlrun_constants
 import mlrun.common.schemas
+import mlrun.model
+import mlrun.runtimes.kubejob
 import tests.conftest
 from mlrun.common.runtimes.constants import PodPhases, RunStates
 from mlrun.common.types import AuthenticationMode
@@ -34,6 +36,7 @@ import framework.utils.singletons.db
 import services.api.crud
 from framework.utils.singletons.db import get_db
 from services.api.runtime_handlers import get_runtime_handler
+from services.api.runtime_handlers.kubejob import KubeRuntimeHandler
 from services.api.tests.unit.runtime_handlers.base import TestRuntimeHandlerBase
 
 
@@ -1173,6 +1176,25 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
 
         assert reason == "Error"
         assert message == "OOMKilled"
+
+    def test_store_uri_source_sets_load_source_on_run(self):
+        """When spec.build.source is store://, load_source_on_run should be set to True."""
+        runtime = mlrun.runtimes.kubejob.KubejobRuntime()
+        runtime.metadata.name = "test-func"
+        runtime.spec.build.source = "store://artifacts/proj/my_code"
+        runtime.spec.build.load_source_on_run = False  # explicitly False
+
+        run = mlrun.model.RunObject()
+        run.metadata.name = "test-run"
+        run.spec.handler = "main"
+
+        handler = KubeRuntimeHandler()
+        cmd, args, extra_env = handler._get_cmd_args(runtime, run)
+
+        # store:// source should be passed as --source arg
+        # (meaning load_source_on_run was auto-set to True)
+        assert "--source" in args
+        assert "store://artifacts/proj/my_code" in args
 
     def _mock_list_resources_pods(self, pod=None):
         pod = pod or self.completed_job_pod

--- a/server/py/services/api/tests/unit/utils/test_functions.py
+++ b/server/py/services/api/tests/unit/utils/test_functions.py
@@ -1,0 +1,94 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock, patch
+
+import mlrun
+import mlrun.errors
+
+from services.api.utils.functions import enrich_function_from_code_artifact
+
+
+def test_enrich_function_merges_artifact_requirements():
+    """Artifact requirements are merged into function build spec."""
+    func = mlrun.new_function("test", kind="job")
+    func.spec.build.source = "store://artifacts/proj/my_code"
+    func.spec.build.requirements = []
+
+    mock_artifact = MagicMock()
+    mock_artifact.spec.requirements = ["pandas>=2.0", "numpy"]
+
+    with patch("mlrun.datastore.get_store_resource", return_value=mock_artifact):
+        enrich_function_from_code_artifact(func, "proj")
+
+    assert "pandas>=2.0" in func.spec.build.requirements
+    assert "numpy" in func.spec.build.requirements
+
+
+def test_enrich_function_user_requirements_take_priority():
+    """User requirements win over artifact requirements for same package."""
+    func = mlrun.new_function("test", kind="job")
+    func.spec.build.source = "store://artifacts/proj/my_code"
+    func.spec.build.requirements = ["pandas>=1.5"]
+
+    mock_artifact = MagicMock()
+    mock_artifact.spec.requirements = ["pandas>=2.0"]
+
+    with patch("mlrun.datastore.get_store_resource", return_value=mock_artifact):
+        enrich_function_from_code_artifact(func, "proj")
+
+    pandas_reqs = [r for r in func.spec.build.requirements if "pandas" in r.lower()]
+    assert len(pandas_reqs) == 1
+    assert "1.5" in pandas_reqs[0]
+
+
+def test_enrich_function_no_requirements_is_noop():
+    """Artifact with no requirements does not change function."""
+    func = mlrun.new_function("test", kind="job")
+    func.spec.build.source = "store://artifacts/proj/my_code"
+    func.spec.build.requirements = ["existing-pkg"]
+
+    mock_artifact = MagicMock()
+    mock_artifact.spec.requirements = None
+
+    with patch("mlrun.datastore.get_store_resource", return_value=mock_artifact):
+        enrich_function_from_code_artifact(func, "proj")
+
+    assert func.spec.build.requirements == ["existing-pkg"]
+
+
+def test_enrich_function_non_store_source_is_noop():
+    """Non-store:// source skips artifact resolution entirely."""
+    func = mlrun.new_function("test", kind="job")
+    func.spec.build.source = "/local/path/code.py"
+
+    with patch("mlrun.datastore.get_store_resource") as mock_get:
+        enrich_function_from_code_artifact(func, "proj")
+        mock_get.assert_not_called()
+
+
+def test_enrich_function_artifact_resolution_failure_raises():
+    """Artifact resolution failure raises clear error."""
+    func = mlrun.new_function("test", kind="job")
+    func.spec.build.source = "store://artifacts/proj/missing"
+
+    with patch(
+        "mlrun.datastore.get_store_resource",
+        side_effect=Exception("artifact not found"),
+    ):
+        try:
+            enrich_function_from_code_artifact(func, "proj")
+            assert False, "Should have raised"
+        except mlrun.errors.MLRunInvalidArgumentError as exc:
+            assert "Cannot resolve code artifact" in str(exc)

--- a/server/py/services/api/utils/functions.py
+++ b/server/py/services/api/utils/functions.py
@@ -160,10 +160,36 @@ def enrich_function_from_code_artifact(
         ) from exc
 
     artifact_requirements = getattr(artifact.spec, "requirements", None)
-    if not artifact_requirements:
-        return
+    if artifact_requirements:
+        function.spec.build.requirements = mlrun.utils.merge_requirements(
+            reqs_priority=function.spec.build.requirements or [],
+            reqs_secondary=artifact_requirements,
+        )
 
-    function.spec.build.requirements = mlrun.utils.merge_requirements(
-        reqs_priority=function.spec.build.requirements or [],
-        reqs_secondary=artifact_requirements,
-    )
+
+def resolve_code_artifact_content(source: str, project: str) -> str:
+    """Resolve store:// artifact and download its code content.
+
+    :param source:  The store:// URI
+    :param project: Project name for artifact resolution
+    :returns: The code content as a string
+    """
+    try:
+        artifact = mlrun.datastore.get_store_resource(source, project=project)
+    except Exception as exc:
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            f"Cannot resolve code artifact {source}: {err_to_str(exc)}"
+        ) from exc
+
+    target_path = artifact.get_target_path()
+    if not target_path:
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            f"Code artifact {source} has no target path"
+        )
+
+    try:
+        return mlrun.get_dataitem(target_path).get().decode("utf-8")
+    except Exception as exc:
+        raise mlrun.errors.MLRunRuntimeError(
+            f"Failed to download code artifact from {target_path}: {err_to_str(exc)}"
+        ) from exc

--- a/server/py/services/api/utils/functions.py
+++ b/server/py/services/api/utils/functions.py
@@ -17,6 +17,8 @@ import traceback
 from http import HTTPStatus
 
 import mlrun.common.schemas
+import mlrun.datastore
+import mlrun.utils
 from mlrun.errors import err_to_str
 from mlrun.run import new_function
 from mlrun.runtimes import RuntimeKinds
@@ -133,3 +135,35 @@ def build_function(
             reason=f"Runtime error: {err_to_str(err)}",
         )
     return fn, ready
+
+
+def enrich_function_from_code_artifact(
+    function: "mlrun.runtimes.base.BaseRuntime",
+    project: str,
+):
+    """Resolve store:// code artifact and merge its requirements into function build spec.
+
+    :param function: The function object to enrich
+    :param project:  Project name for artifact resolution
+    """
+    source = function.spec.build.source or getattr(
+        function.status, "application_source", None
+    )
+    if not source or not mlrun.datastore.is_store_uri(source):
+        return
+
+    try:
+        artifact = mlrun.datastore.get_store_resource(source, project=project)
+    except Exception as exc:
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            f"Cannot resolve code artifact {source}: {err_to_str(exc)}"
+        ) from exc
+
+    artifact_requirements = getattr(artifact.spec, "requirements", None)
+    if not artifact_requirements:
+        return
+
+    function.spec.build.requirements = mlrun.utils.merge_requirements(
+        reqs_priority=function.spec.build.requirements or [],
+        reqs_secondary=artifact_requirements,
+    )

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -769,3 +769,134 @@ def test_artifact_producer_parse_uri(uri, expected_parsed_result):
         deepdiff.DeepDiff(parsed_result, expected_parsed_result, ignore_order=True)
         == {}
     )
+
+
+class TestCodeArtifact:
+    def test_create_with_defaults(self):
+        artifact = mlrun.artifacts.CodeArtifact(key="my-code")
+        assert artifact.kind == "code"
+        assert (
+            artifact.spec.code_type
+            == mlrun.artifacts.code.CodeArtifactCodeType.function
+        )
+        assert artifact.spec.language is None
+
+    def test_create_with_language_and_code_type(self):
+        artifact = mlrun.artifacts.CodeArtifact(
+            key="my-code",
+            language="python:3.9",
+            code_type="workflow",
+        )
+        assert artifact.spec.language == "python:3.9"
+        assert (
+            artifact.spec.code_type
+            == mlrun.artifacts.code.CodeArtifactCodeType.workflow
+        )
+
+    def test_create_with_enum_code_type(self):
+        artifact = mlrun.artifacts.CodeArtifact(
+            key="my-code",
+            code_type=mlrun.artifacts.code.CodeArtifactCodeType.workflow,
+        )
+        assert (
+            artifact.spec.code_type
+            == mlrun.artifacts.code.CodeArtifactCodeType.workflow
+        )
+
+    def test_invalid_code_type_raises(self):
+        with pytest.raises(ValueError):
+            mlrun.artifacts.CodeArtifact(key="bad", code_type="invalid")
+
+    def test_serialization_roundtrip(self):
+        artifact = mlrun.artifacts.CodeArtifact(
+            key="my-code",
+            language="python:3.9",
+            code_type="function",
+        )
+        artifact_dict = artifact.to_dict()
+        assert artifact_dict["kind"] == "code"
+        assert artifact_dict["spec"]["language"] == "python:3.9"
+        assert artifact_dict["spec"]["code_type"] == "function"
+
+        restored = mlrun.artifacts.manager.dict_to_artifact(artifact_dict)
+        assert isinstance(restored, mlrun.artifacts.CodeArtifact)
+        assert restored.spec.language == artifact.spec.language
+        assert restored.spec.code_type == artifact.spec.code_type
+
+    def test_registered_in_artifact_types(self):
+        assert "code" in mlrun.artifacts.manager.artifact_types
+        assert (
+            mlrun.artifacts.manager.artifact_types["code"]
+            is mlrun.artifacts.CodeArtifact
+        )
+
+    def test_category_filtering(self):
+        assert (
+            mlrun.common.schemas.artifact.ArtifactCategories.from_kind("code")
+            == mlrun.common.schemas.artifact.ArtifactCategories.code
+        )
+        kinds, exclude = (
+            mlrun.common.schemas.artifact.ArtifactCategories.code.to_kinds_filter()
+        )
+        assert "code" in kinds
+        assert not exclude
+
+    def test_other_category_excludes_code(self):
+        kinds, exclude = (
+            mlrun.common.schemas.artifact.ArtifactCategories.other.to_kinds_filter()
+        )
+        assert "code" in kinds
+        assert exclude
+
+    def test_log_code_file_via_project(self, new_project_factory):
+        project = new_project_factory("test-code-proj", save=False)
+        artifact = project.log_code_file(
+            "my-func",
+            body="def handler(): pass",
+            language="python:3.9",
+            code_type="function",
+            is_inline=True,
+            artifact_path=str(results_dir),
+        )
+        assert isinstance(artifact, mlrun.artifacts.CodeArtifact)
+        assert artifact.kind == "code"
+        assert artifact.spec.language == "python:3.9"
+        assert (
+            artifact.spec.code_type
+            == mlrun.artifacts.code.CodeArtifactCodeType.function
+        )
+
+    def test_log_code_file_via_context(self, ensure_project):
+        context = mlrun.get_or_create_ctx("test")
+        artifact = context.log_code_file(
+            "my-func",
+            body="def handler(): pass",
+            language="python:3.11",
+            code_type="workflow",
+            is_inline=True,
+            artifact_path=str(results_dir),
+        )
+        assert isinstance(artifact, mlrun.artifacts.CodeArtifact)
+        assert artifact.kind == "code"
+        assert artifact.spec.language == "python:3.11"
+        assert (
+            artifact.spec.code_type
+            == mlrun.artifacts.code.CodeArtifactCodeType.workflow
+        )
+
+    def test_log_code_file_with_local_file(self, tmp_path, new_project_factory):
+        code_file = tmp_path / "my_func.py"
+        code_file.write_text("def handler(): return 42")
+
+        project = new_project_factory("test-code-file", save=False)
+        artifact = project.log_code_file(
+            "my-func",
+            local_path=str(code_file),
+            language="python",
+            code_type="function",
+            artifact_path=str(results_dir),
+            upload=False,
+        )
+        assert isinstance(artifact, mlrun.artifacts.CodeArtifact)
+        assert artifact.kind == "code"
+        assert artifact.spec.language == "python"

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -780,6 +780,7 @@ class TestCodeArtifact:
             == mlrun.artifacts.code.CodeArtifactCodeType.function
         )
         assert artifact.spec.language is None
+        assert artifact.spec.requirements is None
 
     def test_create_with_language_and_code_type(self):
         artifact = mlrun.artifacts.CodeArtifact(
@@ -807,21 +808,35 @@ class TestCodeArtifact:
         with pytest.raises(ValueError):
             mlrun.artifacts.CodeArtifact(key="bad", code_type="invalid")
 
-    def test_serialization_roundtrip(self):
+    def test_create_with_requirements(self):
+        requirements = ["pandas>=2.0", "numpy", "scikit-learn"]
         artifact = mlrun.artifacts.CodeArtifact(
             key="my-code",
             language="python:3.9",
             code_type="function",
+            requirements=requirements,
+        )
+        assert artifact.spec.requirements == requirements
+
+    def test_serialization_roundtrip(self):
+        requirements = ["pandas>=2.0", "numpy"]
+        artifact = mlrun.artifacts.CodeArtifact(
+            key="my-code",
+            language="python:3.9",
+            code_type="function",
+            requirements=requirements,
         )
         artifact_dict = artifact.to_dict()
         assert artifact_dict["kind"] == "code"
         assert artifact_dict["spec"]["language"] == "python:3.9"
         assert artifact_dict["spec"]["code_type"] == "function"
+        assert artifact_dict["spec"]["requirements"] == requirements
 
         restored = mlrun.artifacts.manager.dict_to_artifact(artifact_dict)
         assert isinstance(restored, mlrun.artifacts.CodeArtifact)
         assert restored.spec.language == artifact.spec.language
         assert restored.spec.code_type == artifact.spec.code_type
+        assert restored.spec.requirements == artifact.spec.requirements
 
     def test_registered_in_artifact_types(self):
         assert "code" in mlrun.artifacts.manager.artifact_types
@@ -849,12 +864,14 @@ class TestCodeArtifact:
         assert exclude
 
     def test_log_code_file_via_project(self, new_project_factory):
+        requirements = ["pandas>=2.0", "numpy"]
         project = new_project_factory("test-code-proj", save=False)
         artifact = project.log_code_file(
             "my-func",
             body="def handler(): pass",
             language="python:3.9",
             code_type="function",
+            requirements=requirements,
             is_inline=True,
             artifact_path=str(results_dir),
         )
@@ -865,14 +882,17 @@ class TestCodeArtifact:
             artifact.spec.code_type
             == mlrun.artifacts.code.CodeArtifactCodeType.function
         )
+        assert artifact.spec.requirements == requirements
 
     def test_log_code_file_via_context(self, ensure_project):
+        requirements = ["requests", "boto3>=1.26"]
         context = mlrun.get_or_create_ctx("test")
         artifact = context.log_code_file(
             "my-func",
             body="def handler(): pass",
             language="python:3.11",
             code_type="workflow",
+            requirements=requirements,
             is_inline=True,
             artifact_path=str(results_dir),
         )
@@ -883,6 +903,7 @@ class TestCodeArtifact:
             artifact.spec.code_type
             == mlrun.artifacts.code.CodeArtifactCodeType.workflow
         )
+        assert artifact.spec.requirements == requirements
 
     def test_log_code_file_with_local_file(self, tmp_path, new_project_factory):
         code_file = tmp_path / "my_func.py"

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -2751,3 +2751,66 @@ def test_project_enrich_skips_none_fields():
     # `other` didn't provide status, so base.status should be preserved (same object, same state)
     assert id(base.status) == base_status_id
     assert base.status.state == "offline"
+
+
+def test_init_function_from_dict_store_uri():
+    """set_function with store:// URI stores it in spec.build.source without downloading."""
+    project = mlrun.new_project("test-proj", save=False)
+    project.spec.context = tempfile.mkdtemp()
+
+    func = project.set_function(
+        func="store://artifacts/test-proj/my_func_code",
+        name="my_func",
+        kind="job",
+        handler="main",
+    )
+
+    assert func.spec.build.source == "store://artifacts/test-proj/my_func_code"
+    assert func.spec.default_handler == "main"
+    assert func.metadata.name == "my-func"
+
+
+def test_init_function_from_dict_store_uri_with_repo_raises():
+    """store:// with with_repo=True raises ValueError."""
+    project = mlrun.new_project("test-proj", save=False)
+    project.spec.context = tempfile.mkdtemp()
+
+    with pytest.raises(ValueError, match="with_repo=True is not supported"):
+        project.set_function(
+            func="store://artifacts/test-proj/my_func_code",
+            name="my_func",
+            kind="job",
+            handler="main",
+            with_repo=True,
+        )
+
+
+def test_init_function_from_dict_store_uri_nuclio():
+    """set_function with store:// URI and kind=nuclio stores URI in spec.build.source."""
+    project = mlrun.new_project("test-proj", save=False)
+    project.spec.context = tempfile.mkdtemp()
+
+    func = project.set_function(
+        func="store://artifacts/test-proj/my_func_code",
+        name="my_serving_func",
+        kind="nuclio",
+        handler="main",
+    )
+
+    assert func.spec.build.source == "store://artifacts/test-proj/my_func_code"
+    assert func.kind == "remote"
+
+
+def test_init_function_from_dict_store_uri_serving():
+    """set_function with store:// URI and kind=serving stores URI in spec.build.source."""
+    project = mlrun.new_project("test-proj", save=False)
+    project.spec.context = tempfile.mkdtemp()
+
+    func = project.set_function(
+        func="store://artifacts/test-proj/my_func_code",
+        name="my_serving_func",
+        kind="serving",
+    )
+
+    assert func.spec.build.source == "store://artifacts/test-proj/my_func_code"
+    assert func.kind == "serving"

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -1298,6 +1298,70 @@ def test_export_to_zip(rundb_mock):
     assert mlrun.get_dataitem("memory://x.zip").stat().size
 
 
+def test_export_to_yaml_with_store_function_keeps_store_uri():
+    """export to YAML keeps store:// reference as-is."""
+    project = mlrun.new_project("test-proj", save=False)
+    project.spec.context = tempfile.mkdtemp()
+
+    project.set_function(
+        func="store://artifacts/test-proj/my_func_code",
+        name="my_func",
+        kind="job",
+        handler="main",
+    )
+
+    yaml_path = os.path.join(project.spec.context, "project.yaml")
+    project.export(yaml_path)
+
+    with open(yaml_path) as f:
+        content = f.read()
+
+    assert "store://artifacts/test-proj/my_func_code" in content
+
+
+def test_export_to_zip_with_store_function_downloads_code():
+    """export to zip downloads store:// artifact code and rewrites ref."""
+    project = mlrun.new_project("test-proj", save=False)
+    project.spec.context = tempfile.mkdtemp()
+
+    func = project.set_function(
+        func="store://artifacts/test-proj/my_func_code",
+        name="my_func",
+        kind="job",
+        handler="main",
+    )
+
+    zip_path = os.path.join(tempfile.mkdtemp(), "project.zip")
+
+    with unittest.mock.patch(
+        "mlrun.projects.project._download_store_artifact_for_export"
+    ) as mock_dl:
+        # Simulate successful download
+        mock_dl.return_value = ".mlrun/code/my_func.py"
+        # Create the dummy file so it exists in the zip
+        code_dir = os.path.join(project.spec.context, ".mlrun", "code")
+        os.makedirs(code_dir, exist_ok=True)
+        with open(os.path.join(code_dir, "my_func.py"), "w") as f:
+            f.write("def main():\n    pass\n")
+
+        project.export(zip_path)
+
+    assert os.path.exists(zip_path)
+    # After export, in-memory project should still have store:// ref
+    assert func.spec.build.source == "store://artifacts/test-proj/my_func_code"
+
+    # Verify the zip contains the downloaded code file and the rewritten project.yaml
+    with zipfile.ZipFile(zip_path, "r") as zipf:
+        names = zipf.namelist()
+        assert ".mlrun/code/my_func.py" in names
+        assert "project.yaml" in names
+
+        # Verify project.yaml inside the zip has the local path, not store://
+        yaml_content = zipf.read("project.yaml").decode()
+        assert "store://artifacts/test-proj/my_func_code" not in yaml_content
+        assert ".mlrun/code/my_func.py" in yaml_content
+
+
 def test_function_receives_project_artifact_path(rundb_mock):
     func_path = str(pathlib.Path(__file__).parent / "assets" / "handler.py")
     mlrun.mlconf.artifact_path = "/tmp"

--- a/tests/runtimes/test_application.py
+++ b/tests/runtimes/test_application.py
@@ -1128,7 +1128,7 @@ def test_upload_source_as_artifact(tmp_path):
     mock_artifact.uri = "store://artifacts/test-project/application-test-source"
 
     mock_project = unittest.mock.MagicMock()
-    mock_project.log_artifact.return_value = mock_artifact
+    mock_project.log_code_file.return_value = mock_artifact
 
     with unittest.mock.patch(
         "mlrun.get_or_create_project", return_value=mock_project
@@ -1139,9 +1139,11 @@ def test_upload_source_as_artifact(tmp_path):
     mock_get_project.assert_called_once_with("test-project")
 
     # Verify artifact was logged with correct parameters
-    mock_project.log_artifact.assert_called_once_with(
-        item="application-test-source",
+    mock_project.log_code_file.assert_called_once_with(
+        key="application-test-source",
         local_path=str(source_file),
+        language="python",
+        code_type="function",
         artifact_path=mlrun.common.constants.MLRUN_INTERNAL_ARTIFACT_PATH,
         upload=True,
         labels={

--- a/tests/system/runtimes/test_code_artifact.py
+++ b/tests/system/runtimes/test_code_artifact.py
@@ -224,3 +224,68 @@ class TestCodeArtifact(TestMLRunSystem):
         # Next run should get V2 (job downloads fresh each time)
         run2 = func.run(local=False)
         assert run2.status.results.get("return") == "v2"
+
+    def test_job_function_from_store_artifact_with_requirements(self):
+        """Job function from store:// artifact with requirements gets deps installed at build time."""
+        # Use 'requests' as a test package — it's common but may not be in base image
+        code = (
+            "import requests\n"
+            "def handler(context):\n"
+            "    context.log_result('requests_version', requests.__version__)\n"
+        )
+        s3_path = self._s3_path("func_with_deps.py")
+        self._upload_code(s3_path, code)
+
+        self.project.log_code_file(
+            "func-with-deps",
+            target_path=s3_path,
+            language="python",
+            code_type="function",
+            requirements=["requests"],
+        )
+
+        func = self.project.set_function(
+            func=f"store://artifacts/{self.project_name}/func-with-deps",
+            name="job-with-deps",
+            kind="job",
+            handler="handler",
+            image=self.image,
+        )
+
+        run = func.run(local=False)
+        assert run.status.state == "completed"
+        assert run.status.results.get("requests_version")
+
+    def test_nuclio_function_from_store_artifact_with_requirements(self):
+        """Nuclio function from store:// artifact with requirements gets deps installed at build time."""
+        code = (
+            "import requests\n"
+            "def handler(context, event):\n"
+            "    return context.Response(\n"
+            "        body=requests.__version__,\n"
+            "        content_type='text/plain',\n"
+            "    )\n"
+        )
+        s3_path = self._s3_path("nuclio_with_deps.py")
+        self._upload_code(s3_path, code)
+
+        self.project.log_code_file(
+            "nuclio-with-deps",
+            target_path=s3_path,
+            language="python",
+            code_type="function",
+            requirements=["requests"],
+        )
+
+        func = self.project.set_function(
+            func=f"store://artifacts/{self.project_name}/nuclio-with-deps",
+            name="nuclio-with-deps",
+            kind="nuclio",
+            handler="handler:handler",
+            image=self.image,
+        )
+        self.project.deploy_function("nuclio-with-deps")
+
+        resp = func.invoke("")
+        # Should return the requests version string (not an import error)
+        assert resp.decode().strip()

--- a/tests/system/runtimes/test_code_artifact.py
+++ b/tests/system/runtimes/test_code_artifact.py
@@ -1,0 +1,226 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import uuid
+
+import pytest
+
+import mlrun
+import mlrun.datastore
+from mlrun.datastore.datastore_profile import DatastoreProfileS3
+from tests.system.base import TestMLRunSystem
+
+test_environment = TestMLRunSystem._get_env_from_file()
+
+
+@TestMLRunSystem.skip_test_if_env_not_configured
+@pytest.mark.skipif(
+    not test_environment.get("AWS_ACCESS_KEY_ID"),
+    reason="AWS_ACCESS_KEY_ID is not set",
+)
+@pytest.mark.skipif(
+    not test_environment.get("AWS_SECRET_ACCESS_KEY"),
+    reason="AWS_SECRET_ACCESS_KEY is not set",
+)
+@pytest.mark.skipif(
+    not test_environment.get("AWS_BUCKET_NAME"),
+    reason="AWS_BUCKET_NAME is not set",
+)
+class TestCodeArtifact(TestMLRunSystem):
+    """System tests for loading functions from store:// code artifacts (ML-11980)."""
+
+    project_name = "code-artifact-system-test"
+    image = "mlrun/mlrun"
+
+    def _s3_path(self, filename: str) -> str:
+        bucket = test_environment["AWS_BUCKET_NAME"]
+        run_id = uuid.uuid4().hex[:8]
+        return f"s3://{bucket}/test-code-artifact/{run_id}/{filename}"
+
+    def _upload_code(self, s3_path: str, code: str):
+        mlrun.get_dataitem(s3_path).put(code.encode())
+
+    def test_job_function_from_store_artifact_s3(self):
+        """Job function loads code from store:// artifact pointing to S3."""
+        code = (
+            "def handler(context):\n"
+            "    context.logger.info('hello from artifact')\n"
+            "    context.log_result('return', 42)\n"
+        )
+        s3_path = self._s3_path("job_func.py")
+        self._upload_code(s3_path, code)
+
+        self.project.log_code_file(
+            "job-func-code",
+            target_path=s3_path,
+            language="python",
+            code_type="function",
+        )
+
+        func = self.project.set_function(
+            func=f"store://artifacts/{self.project_name}/job-func-code",
+            name="job-from-artifact",
+            kind="job",
+            handler="handler",
+            image=self.image,
+        )
+
+        run = func.run(local=False)
+        assert run.status.state == "completed"
+        assert run.status.results.get("return") == 42
+
+        # Verify store:// is preserved in DB
+        db_func = self.project.get_function("job-from-artifact")
+        assert mlrun.datastore.is_store_uri(db_func.spec.build.source)
+
+    def test_job_function_from_store_artifact_ds_profile(self):
+        """Job function loads code via ds:// datastore profile."""
+        bucket = test_environment["AWS_BUCKET_NAME"]
+        profile = DatastoreProfileS3(
+            name="test-code-profile",
+            bucket=bucket,
+            access_key_id=test_environment["AWS_ACCESS_KEY_ID"],
+            secret_key=test_environment["AWS_SECRET_ACCESS_KEY"],
+        )
+        self.project.register_datastore_profile(profile)
+
+        run_id = uuid.uuid4().hex[:8]
+        ds_path = f"ds://test-code-profile/test-code-artifact/{run_id}/ds_func.py"
+
+        code = (
+            "def handler(context):\n"
+            "    context.log_result('return', 'ds-profile-works')\n"
+        )
+        mlrun.get_dataitem(ds_path).put(code.encode())
+
+        self.project.log_code_file(
+            "ds-func-code",
+            target_path=ds_path,
+            language="python",
+            code_type="function",
+        )
+
+        func = self.project.set_function(
+            func=f"store://artifacts/{self.project_name}/ds-func-code",
+            name="job-from-ds-profile",
+            kind="job",
+            handler="handler",
+            image=self.image,
+        )
+
+        run = func.run(local=False)
+        assert run.status.state == "completed"
+        assert run.status.results.get("return") == "ds-profile-works"
+
+    def test_nuclio_function_from_store_artifact(self):
+        """Nuclio function uses init container to load code from store:// artifact."""
+        code = (
+            "def handler(context, event):\n"
+            "    return context.Response(\n"
+            "        body='from-artifact',\n"
+            "        content_type='text/plain',\n"
+            "    )\n"
+        )
+        s3_path = self._s3_path("nuclio_func.py")
+        self._upload_code(s3_path, code)
+
+        self.project.log_code_file(
+            "nuclio-code",
+            target_path=s3_path,
+            language="python",
+            code_type="function",
+        )
+
+        func = self.project.set_function(
+            func=f"store://artifacts/{self.project_name}/nuclio-code",
+            name="nuclio-from-artifact",
+            kind="nuclio",
+            handler="handler:handler",
+            image=self.image,
+        )
+        self.project.deploy_function("nuclio-from-artifact")
+
+        resp = func.invoke("")
+        assert resp.decode() == "from-artifact"
+
+        # Verify no credentials leaked in function spec
+        db_func = self.project.get_function("nuclio-from-artifact")
+        for key, value in (db_func.spec.config or {}).items():
+            assert "AWS_SECRET" not in str(value), f"Credential leak in {key}"
+
+    def test_shared_artifact_across_functions(self):
+        """Two job functions reference the same store:// artifact."""
+        code = (
+            "def handler(context):\n"
+            "    context.log_result('return', 'shared-code')\n"
+        )
+        s3_path = self._s3_path("shared.py")
+        self._upload_code(s3_path, code)
+
+        self.project.log_code_file(
+            "shared-code",
+            target_path=s3_path,
+            language="python",
+            code_type="function",
+        )
+
+        store_uri = f"store://artifacts/{self.project_name}/shared-code"
+
+        func_a = self.project.set_function(
+            func=store_uri, name="func-a", kind="job",
+            handler="handler", image=self.image,
+        )
+        func_b = self.project.set_function(
+            func=store_uri, name="func-b", kind="job",
+            handler="handler", image=self.image,
+        )
+
+        run_a = func_a.run(local=False)
+        run_b = func_b.run(local=False)
+
+        assert run_a.status.state == "completed"
+        assert run_b.status.state == "completed"
+        assert run_a.status.results.get("return") == "shared-code"
+        assert run_b.status.results.get("return") == "shared-code"
+
+    def test_redeploy_picks_up_updated_artifact(self):
+        """After updating artifact code at the same S3 path, next run() gets the new version."""
+        s3_path = self._s3_path("versioned.py")
+
+        # V1
+        self._upload_code(
+            s3_path, "def handler(context):\n    context.log_result('return', 'v1')\n"
+        )
+        self.project.log_code_file(
+            "versioned-code", target_path=s3_path, language="python",
+        )
+
+        func = self.project.set_function(
+            func=f"store://artifacts/{self.project_name}/versioned-code",
+            name="versioned-func",
+            kind="job",
+            handler="handler",
+            image=self.image,
+        )
+        run1 = func.run(local=False)
+        assert run1.status.results.get("return") == "v1"
+
+        # V2 -- update the file at the same S3 path
+        self._upload_code(
+            s3_path, "def handler(context):\n    context.log_result('return', 'v2')\n"
+        )
+
+        # Next run should get V2 (job downloads fresh each time)
+        run2 = func.run(local=False)
+        assert run2.status.results.get("return") == "v2"

--- a/tests/system/runtimes/test_code_artifact.py
+++ b/tests/system/runtimes/test_code_artifact.py
@@ -18,110 +18,78 @@ import pytest
 
 import mlrun
 import mlrun.datastore
-from mlrun.datastore.datastore_profile import DatastoreProfileS3
 from tests.system.base import TestMLRunSystem
 
 test_environment = TestMLRunSystem._get_env_from_file()
 
 
 @TestMLRunSystem.skip_test_if_env_not_configured
-@pytest.mark.skipif(
-    not test_environment.get("AWS_ACCESS_KEY_ID"),
-    reason="AWS_ACCESS_KEY_ID is not set",
-)
-@pytest.mark.skipif(
-    not test_environment.get("AWS_SECRET_ACCESS_KEY"),
-    reason="AWS_SECRET_ACCESS_KEY is not set",
-)
-@pytest.mark.skipif(
-    not test_environment.get("AWS_BUCKET_NAME"),
-    reason="AWS_BUCKET_NAME is not set",
-)
+@pytest.mark.enterprise
 class TestCodeArtifact(TestMLRunSystem):
     """System tests for loading functions from store:// code artifacts (ML-11980)."""
 
     project_name = "code-artifact-system-test"
-    image = "mlrun/mlrun"
+    image = "artifactory.iguazeng.com:10557/mlrun:unstable"
 
-    def _s3_path(self, filename: str) -> str:
-        bucket = test_environment["AWS_BUCKET_NAME"]
+    @classmethod
+    def custom_setup_class(cls):
+        # Trigger migrations if needed (new deployment may require it)
+        try:
+            cls._run_db.trigger_migrations()
+        except Exception:
+            pass  # best effort — may already be migrated
+
+    def _v3io_path(self, filename: str) -> str:
         run_id = uuid.uuid4().hex[:8]
-        return f"s3://{bucket}/test-code-artifact/{run_id}/{filename}"
+        return f"v3io:///projects/{self.project_name}/test-code-artifact/{run_id}/{filename}"
 
-    def _upload_code(self, s3_path: str, code: str):
-        mlrun.get_dataitem(s3_path).put(code.encode())
+    def _upload_code(self, path: str, code: str):
+        mlrun.get_dataitem(path).put(code.encode())
 
-    def test_job_function_from_store_artifact_s3(self):
-        """Job function loads code from store:// artifact pointing to S3."""
+    def _set_function(self, **kwargs):
+        """Set function with image_pull_policy=Always to avoid stale cached images."""
+        func = self.project.set_function(image=self.image, **kwargs)
+        func.spec.image_pull_policy = "Always"
+        return func
+
+    def test_job_function_from_store_artifact(self):
+        """Job function loads code from store:// artifact pointing to v3io."""
         code = (
             "def handler(context):\n"
             "    context.logger.info('hello from artifact')\n"
             "    context.log_result('return', 42)\n"
         )
-        s3_path = self._s3_path("job_func.py")
-        self._upload_code(s3_path, code)
+        v3io_path = self._v3io_path("job_func.py")
+        self._upload_code(v3io_path, code)
 
         self.project.log_code_file(
             "job-func-code",
-            target_path=s3_path,
+            target_path=v3io_path,
             language="python",
             code_type="function",
         )
 
-        func = self.project.set_function(
+        func = self._set_function(
             func=f"store://artifacts/{self.project_name}/job-func-code",
             name="job-from-artifact",
             kind="job",
-            handler="handler",
-            image=self.image,
+            handler="job_func.handler",
         )
 
-        run = func.run(local=False)
-        assert run.status.state == "completed"
+        run = func.run(local=False, watch=False)
+        run.wait_for_completion(timeout=300)
+        if run.status.state == "error":
+            self._logger.error(
+                "Run failed",
+                error=run.status.error,
+                status=run.status.to_dict(),
+            )
+        assert run.status.state == "completed", f"Run failed: {run.status.error}"
         assert run.status.results.get("return") == 42
 
         # Verify store:// is preserved in DB
         db_func = self.project.get_function("job-from-artifact")
         assert mlrun.datastore.is_store_uri(db_func.spec.build.source)
-
-    def test_job_function_from_store_artifact_ds_profile(self):
-        """Job function loads code via ds:// datastore profile."""
-        bucket = test_environment["AWS_BUCKET_NAME"]
-        profile = DatastoreProfileS3(
-            name="test-code-profile",
-            bucket=bucket,
-            access_key_id=test_environment["AWS_ACCESS_KEY_ID"],
-            secret_key=test_environment["AWS_SECRET_ACCESS_KEY"],
-        )
-        self.project.register_datastore_profile(profile)
-
-        run_id = uuid.uuid4().hex[:8]
-        ds_path = f"ds://test-code-profile/test-code-artifact/{run_id}/ds_func.py"
-
-        code = (
-            "def handler(context):\n"
-            "    context.log_result('return', 'ds-profile-works')\n"
-        )
-        mlrun.get_dataitem(ds_path).put(code.encode())
-
-        self.project.log_code_file(
-            "ds-func-code",
-            target_path=ds_path,
-            language="python",
-            code_type="function",
-        )
-
-        func = self.project.set_function(
-            func=f"store://artifacts/{self.project_name}/ds-func-code",
-            name="job-from-ds-profile",
-            kind="job",
-            handler="handler",
-            image=self.image,
-        )
-
-        run = func.run(local=False)
-        assert run.status.state == "completed"
-        assert run.status.results.get("return") == "ds-profile-works"
 
     def test_nuclio_function_from_store_artifact(self):
         """Nuclio function uses init container to load code from store:// artifact."""
@@ -132,22 +100,21 @@ class TestCodeArtifact(TestMLRunSystem):
             "        content_type='text/plain',\n"
             "    )\n"
         )
-        s3_path = self._s3_path("nuclio_func.py")
-        self._upload_code(s3_path, code)
+        v3io_path = self._v3io_path("nuclio_func.py")
+        self._upload_code(v3io_path, code)
 
         self.project.log_code_file(
             "nuclio-code",
-            target_path=s3_path,
+            target_path=v3io_path,
             language="python",
             code_type="function",
         )
 
-        func = self.project.set_function(
+        func = self._set_function(
             func=f"store://artifacts/{self.project_name}/nuclio-code",
             name="nuclio-from-artifact",
             kind="nuclio",
             handler="handler:handler",
-            image=self.image,
         )
         self.project.deploy_function("nuclio-from-artifact")
 
@@ -157,33 +124,38 @@ class TestCodeArtifact(TestMLRunSystem):
         # Verify no credentials leaked in function spec
         db_func = self.project.get_function("nuclio-from-artifact")
         for key, value in (db_func.spec.config or {}).items():
-            assert "AWS_SECRET" not in str(value), f"Credential leak in {key}"
+            assert "V3IO_ACCESS_KEY" not in str(
+                value
+            ), f"Credential leak in {key}"
 
     def test_shared_artifact_across_functions(self):
         """Two job functions reference the same store:// artifact."""
         code = (
-            "def handler(context):\n"
-            "    context.log_result('return', 'shared-code')\n"
+            "def handler(context):\n    context.log_result('return', 'shared-code')\n"
         )
-        s3_path = self._s3_path("shared.py")
-        self._upload_code(s3_path, code)
+        v3io_path = self._v3io_path("shared.py")
+        self._upload_code(v3io_path, code)
 
         self.project.log_code_file(
             "shared-code",
-            target_path=s3_path,
+            target_path=v3io_path,
             language="python",
             code_type="function",
         )
 
         store_uri = f"store://artifacts/{self.project_name}/shared-code"
 
-        func_a = self.project.set_function(
-            func=store_uri, name="func-a", kind="job",
-            handler="handler", image=self.image,
+        func_a = self._set_function(
+            func=store_uri,
+            name="func-a",
+            kind="job",
+            handler="handler",
         )
-        func_b = self.project.set_function(
-            func=store_uri, name="func-b", kind="job",
-            handler="handler", image=self.image,
+        func_b = self._set_function(
+            func=store_uri,
+            name="func-b",
+            kind="job",
+            handler="handler",
         )
 
         run_a = func_a.run(local=False)
@@ -195,30 +167,33 @@ class TestCodeArtifact(TestMLRunSystem):
         assert run_b.status.results.get("return") == "shared-code"
 
     def test_redeploy_picks_up_updated_artifact(self):
-        """After updating artifact code at the same S3 path, next run() gets the new version."""
-        s3_path = self._s3_path("versioned.py")
+        """After updating artifact code at the same path, next run() gets the new version."""
+        v3io_path = self._v3io_path("versioned.py")
 
         # V1
         self._upload_code(
-            s3_path, "def handler(context):\n    context.log_result('return', 'v1')\n"
+            v3io_path,
+            "def handler(context):\n    context.log_result('return', 'v1')\n",
         )
         self.project.log_code_file(
-            "versioned-code", target_path=s3_path, language="python",
+            "versioned-code",
+            target_path=v3io_path,
+            language="python",
         )
 
-        func = self.project.set_function(
+        func = self._set_function(
             func=f"store://artifacts/{self.project_name}/versioned-code",
             name="versioned-func",
             kind="job",
             handler="handler",
-            image=self.image,
         )
         run1 = func.run(local=False)
         assert run1.status.results.get("return") == "v1"
 
-        # V2 -- update the file at the same S3 path
+        # V2 -- update the file at the same path
         self._upload_code(
-            s3_path, "def handler(context):\n    context.log_result('return', 'v2')\n"
+            v3io_path,
+            "def handler(context):\n    context.log_result('return', 'v2')\n",
         )
 
         # Next run should get V2 (job downloads fresh each time)
@@ -227,29 +202,27 @@ class TestCodeArtifact(TestMLRunSystem):
 
     def test_job_function_from_store_artifact_with_requirements(self):
         """Job function from store:// artifact with requirements gets deps installed at build time."""
-        # Use 'requests' as a test package — it's common but may not be in base image
         code = (
             "import requests\n"
             "def handler(context):\n"
             "    context.log_result('requests_version', requests.__version__)\n"
         )
-        s3_path = self._s3_path("func_with_deps.py")
-        self._upload_code(s3_path, code)
+        v3io_path = self._v3io_path("func_with_deps.py")
+        self._upload_code(v3io_path, code)
 
         self.project.log_code_file(
             "func-with-deps",
-            target_path=s3_path,
+            target_path=v3io_path,
             language="python",
             code_type="function",
             requirements=["requests"],
         )
 
-        func = self.project.set_function(
+        func = self._set_function(
             func=f"store://artifacts/{self.project_name}/func-with-deps",
             name="job-with-deps",
             kind="job",
             handler="handler",
-            image=self.image,
         )
 
         run = func.run(local=False)
@@ -266,23 +239,22 @@ class TestCodeArtifact(TestMLRunSystem):
             "        content_type='text/plain',\n"
             "    )\n"
         )
-        s3_path = self._s3_path("nuclio_with_deps.py")
-        self._upload_code(s3_path, code)
+        v3io_path = self._v3io_path("nuclio_with_deps.py")
+        self._upload_code(v3io_path, code)
 
         self.project.log_code_file(
             "nuclio-with-deps",
-            target_path=s3_path,
+            target_path=v3io_path,
             language="python",
             code_type="function",
             requirements=["requests"],
         )
 
-        func = self.project.set_function(
+        func = self._set_function(
             func=f"store://artifacts/{self.project_name}/nuclio-with-deps",
             name="nuclio-with-deps",
             kind="nuclio",
             handler="handler:handler",
-            image=self.image,
         )
         self.project.deploy_function("nuclio-with-deps")
 

--- a/tests/system/runtimes/test_code_artifact.py
+++ b/tests/system/runtimes/test_code_artifact.py
@@ -114,7 +114,7 @@ class TestCodeArtifact(TestMLRunSystem):
             func=f"store://artifacts/{self.project_name}/nuclio-code",
             name="nuclio-from-artifact",
             kind="nuclio",
-            handler="handler:handler",
+            handler="nuclio_func:handler",
         )
         self.project.deploy_function("nuclio-from-artifact")
 
@@ -149,20 +149,22 @@ class TestCodeArtifact(TestMLRunSystem):
             func=store_uri,
             name="func-a",
             kind="job",
-            handler="handler",
+            handler="shared.handler",
         )
         func_b = self._set_function(
             func=store_uri,
             name="func-b",
             kind="job",
-            handler="handler",
+            handler="shared.handler",
         )
 
-        run_a = func_a.run(local=False)
-        run_b = func_b.run(local=False)
+        run_a = func_a.run(local=False, watch=False)
+        run_b = func_b.run(local=False, watch=False)
+        run_a.wait_for_completion(timeout=300)
+        run_b.wait_for_completion(timeout=300)
 
-        assert run_a.status.state == "completed"
-        assert run_b.status.state == "completed"
+        assert run_a.status.state == "completed", f"func-a failed: {run_a.status.error}"
+        assert run_b.status.state == "completed", f"func-b failed: {run_b.status.error}"
         assert run_a.status.results.get("return") == "shared-code"
         assert run_b.status.results.get("return") == "shared-code"
 
@@ -185,9 +187,11 @@ class TestCodeArtifact(TestMLRunSystem):
             func=f"store://artifacts/{self.project_name}/versioned-code",
             name="versioned-func",
             kind="job",
-            handler="handler",
+            handler="versioned.handler",
         )
-        run1 = func.run(local=False)
+        run1 = func.run(local=False, watch=False)
+        run1.wait_for_completion(timeout=300)
+        assert run1.status.state == "completed", f"V1 run failed: {run1.status.error}"
         assert run1.status.results.get("return") == "v1"
 
         # V2 -- update the file at the same path
@@ -197,7 +201,9 @@ class TestCodeArtifact(TestMLRunSystem):
         )
 
         # Next run should get V2 (job downloads fresh each time)
-        run2 = func.run(local=False)
+        run2 = func.run(local=False, watch=False)
+        run2.wait_for_completion(timeout=300)
+        assert run2.status.state == "completed", f"V2 run failed: {run2.status.error}"
         assert run2.status.results.get("return") == "v2"
 
     def test_job_function_from_store_artifact_with_requirements(self):
@@ -222,11 +228,12 @@ class TestCodeArtifact(TestMLRunSystem):
             func=f"store://artifacts/{self.project_name}/func-with-deps",
             name="job-with-deps",
             kind="job",
-            handler="handler",
+            handler="func_with_deps.handler",
         )
 
-        run = func.run(local=False)
-        assert run.status.state == "completed"
+        run = func.run(local=False, watch=False)
+        run.wait_for_completion(timeout=300)
+        assert run.status.state == "completed", f"Run failed: {run.status.error}"
         assert run.status.results.get("requests_version")
 
     def test_nuclio_function_from_store_artifact_with_requirements(self):
@@ -254,7 +261,7 @@ class TestCodeArtifact(TestMLRunSystem):
             func=f"store://artifacts/{self.project_name}/nuclio-with-deps",
             name="nuclio-with-deps",
             kind="nuclio",
-            handler="handler:handler",
+            handler="nuclio_with_deps:handler",
         )
         self.project.deploy_function("nuclio-with-deps")
 

--- a/tests/system/runtimes/test_code_artifact.py
+++ b/tests/system/runtimes/test_code_artifact.py
@@ -92,7 +92,11 @@ class TestCodeArtifact(TestMLRunSystem):
         assert mlrun.datastore.is_store_uri(db_func.spec.build.source)
 
     def test_nuclio_function_from_store_artifact(self):
-        """Nuclio function uses init container to load code from store:// artifact."""
+        """Nuclio function with store:// — build-time mode (default).
+
+        Server resolves artifact, embeds code as functionSourceCode.
+        No init container needed.
+        """
         code = (
             "def handler(context, event):\n"
             "    return context.Response(\n"
@@ -116,6 +120,7 @@ class TestCodeArtifact(TestMLRunSystem):
             kind="nuclio",
             handler="nuclio_func:handler",
         )
+        # Default: load_source_on_run=False → build-time resolution
         self.project.deploy_function("nuclio-from-artifact")
 
         resp = func.invoke("")
@@ -127,6 +132,41 @@ class TestCodeArtifact(TestMLRunSystem):
             assert "V3IO_ACCESS_KEY" not in str(
                 value
             ), f"Credential leak in {key}"
+
+    def test_nuclio_function_from_store_artifact_runtime_mode(self):
+        """Nuclio function with store:// — runtime mode (load_source_on_run=True).
+
+        Init container downloads code at pod startup. Wrapper imports handler
+        from PYTHONPATH. Code updates without rebuild.
+        """
+        code = (
+            "def handler(context, event):\n"
+            "    return context.Response(\n"
+            "        body='runtime-mode',\n"
+            "        content_type='text/plain',\n"
+            "    )\n"
+        )
+        v3io_path = self._v3io_path("nuclio_rt.py")
+        self._upload_code(v3io_path, code)
+
+        self.project.log_code_file(
+            "nuclio-rt-code",
+            target_path=v3io_path,
+            language="python",
+            code_type="function",
+        )
+
+        func = self._set_function(
+            func=f"store://artifacts/{self.project_name}/nuclio-rt-code",
+            name="nuclio-runtime-mode",
+            kind="nuclio",
+            handler="nuclio_rt:handler",
+        )
+        func.spec.build.load_source_on_run = True
+        self.project.deploy_function("nuclio-runtime-mode")
+
+        resp = func.invoke("")
+        assert resp.decode() == "runtime-mode"
 
     def test_shared_artifact_across_functions(self):
         """Two job functions reference the same store:// artifact."""

--- a/tests/system/runtimes/test_code_artifact.py
+++ b/tests/system/runtimes/test_code_artifact.py
@@ -29,7 +29,9 @@ class TestCodeArtifact(TestMLRunSystem):
     """System tests for loading functions from store:// code artifacts (ML-11980)."""
 
     project_name = "code-artifact-system-test"
-    image = "artifactory.iguazeng.com:10557/mlrun:unstable"
+    # Use default mlrun/mlrun image — the cluster's installed mlrun image.
+    # Don't specify an external registry path to avoid Nuclio runRegistry prefix issues.
+    image = "mlrun/mlrun"
 
     @classmethod
     def custom_setup_class(cls):
@@ -47,10 +49,8 @@ class TestCodeArtifact(TestMLRunSystem):
         mlrun.get_dataitem(path).put(code.encode())
 
     def _set_function(self, **kwargs):
-        """Set function with image_pull_policy=Always to avoid stale cached images."""
-        func = self.project.set_function(image=self.image, **kwargs)
-        func.spec.image_pull_policy = "Always"
-        return func
+        """Set function with the test image."""
+        return self.project.set_function(image=self.image, **kwargs)
 
     def test_job_function_from_store_artifact(self):
         """Job function loads code from store:// artifact pointing to v3io."""

--- a/tests/utils/test_clones.py
+++ b/tests/utils/test_clones.py
@@ -224,6 +224,56 @@ def test_load_source_code_tgz(tmp_path):
     mock_clone_tgz.assert_called_once_with(source_uri, target_dir)
 
 
+def test_extract_source_store_uri_delegates_to_load_source_code():
+    """extract_source with store:// URI delegates to load_source_code."""
+    with unittest.mock.patch("mlrun.utils.clones.load_source_code") as mock_load:
+        mock_load.return_value = "/tmp/code/my_func.py"
+        result = mlrun.utils.clones.extract_source(
+            source="store://artifacts/proj/my_func",
+            workdir="/tmp/workdir",
+            project="proj",
+        )
+        mock_load.assert_called_once_with(
+            source_uri="store://artifacts/proj/my_func",
+            target_dir="/tmp/workdir",
+            project="proj",
+        )
+        assert result == "/tmp/code/my_func.py"
+
+
+def test_extract_source_store_uri_without_project():
+    """extract_source with store:// but no project passes project=None."""
+    with unittest.mock.patch("mlrun.utils.clones.load_source_code") as mock_load:
+        mock_load.return_value = "/tmp/code/my_func.py"
+        mlrun.utils.clones.extract_source(
+            source="store://artifacts/proj/my_func",
+            workdir="/tmp/workdir",
+        )
+        mock_load.assert_called_once_with(
+            source_uri="store://artifacts/proj/my_func",
+            target_dir="/tmp/workdir",
+            project=None,
+        )
+
+
+def test_extract_source_store_uri_default_workdir():
+    """extract_source with store:// and no workdir uses default ./code dir."""
+    with unittest.mock.patch("mlrun.utils.clones.load_source_code") as mock_load:
+        mock_load.return_value = "/tmp/code/my_func.py"
+        import os
+
+        expected_target = os.path.realpath("./code")
+        mlrun.utils.clones.extract_source(
+            source="store://artifacts/proj/my_func",
+            project="proj",
+        )
+        mock_load.assert_called_once_with(
+            source_uri="store://artifacts/proj/my_func",
+            target_dir=expected_target,
+            project="proj",
+        )
+
+
 def test_load_source_code_archive_failure(tmp_path):
     source_uri = "https://example.com/source.zip"
     target_dir = str(tmp_path / "target")


### PR DESCRIPTION
## Summary by Sourcery

Add first-class support for code artifacts as a dedicated artifact type and integrate store:// code URIs across runtimes, projects, and exports so functions can load code and its dependencies from artifacts at build or runtime.

New Features:
- Introduce a CodeArtifact type with language, code_type, and requirements metadata and expose it via new log_code_file helpers on project and run contexts.
- Enable functions to be created directly from store:// code artifact URIs, including job, nuclio, serving, and application runtimes.
- Support resolving store:// code artifacts for Nuclio both at build time and at runtime via init containers, including dependency merging from artifact requirements.

Enhancements:
- Update project export to handle store:// function sources by optionally downloading code into zip exports while preserving store:// references in YAML exports.
- Extend source extraction and local runtimes to handle store:// URIs via the existing load_source_code flow, including returning directories for use as working dirs and PYTHONPATH.
- Enhance kubejob runtime handling so store:// sources automatically enable runtime code loading and wire the source into execution arguments.
- Preserve original store:// sources for Nuclio functions across redeployments using application_source and avoid Nuclio registry path mismatches by reusing the function image for init containers.
- Expand artifact category schema and artifact manager registration to include the new code artifact kind, and adjust patching automation image mapping for the mlrun component.

Tests:
- Add extensive unit, integration, and system tests covering CodeArtifact behavior, project export with store:// functions, store:// handling in clones and runtimes, Nuclio source loading decisions, and code-logging helpers.